### PR TITLE
Add fit framework

### DIFF
--- a/fit/OspreyFit.m
+++ b/fit/OspreyFit.m
@@ -1,0 +1,100 @@
+function [MRSCont] = OspreyFit(MRSCont)
+%% [MRSCont] = OspreyFit(MRSCont)
+%   This function performs spectral fitting on MRS data loaded previously
+%   using OspreyLoad.
+%
+%   The method of fit, fitting range, included metabolites and other 
+%   settings are set in the job file.
+%
+%   USAGE:
+%       MRSCont = OspreyFit(MRSCont);
+%
+%   INPUTS:
+%       MRSCont     = Osprey MRS data container.
+%
+%   OUTPUTS:
+%       MRSCont     = Osprey MRS data container.
+%
+%   AUTHOR:
+%       Dr. Georg Oeltzschner (Johns Hopkins University, 2019-02-24)
+%       goeltzs1@jhmi.edu
+%   
+%   CREDITS:    
+%       This code is based on numerous functions from the FID-A toolbox by
+%       Dr. Jamie Near (McGill University)
+%       https://github.com/CIC-methods/FID-A
+%       Simpson et al., Magn Reson Med 77:23-33 (2017)
+%
+%   HISTORY:
+%       2019-02-24: First version of the code.
+
+% Check that OspreyLoad has been run before
+if ~MRSCont.flags.didLoadData
+    error('Trying to fit data, but raw data has not been loaded yet. Run OspreyLoad first.')
+end
+
+% Check that OspreyProcess has been run before
+if ~MRSCont.flags.didProcess
+    error('Trying to fit data, but loaded data has not been process yet. Run OspreyProcess first.')
+end
+
+%% Load fit settings, prepare data and pass it on to the fitting algorithm
+% Close any remaining open figures
+close all;
+
+% Initialise the fit - this step includes:
+% - Parse the correct basis set
+% - Apply settings on which metabolites/MM/lipids to include in the fit
+% - Check for inconsistencies between basis set and data
+[MRSCont] = osp_fitInitialise(MRSCont);
+
+% Call the fit functions (depending on sequence type)
+if MRSCont.flags.isUnEdited
+    [MRSCont] = osp_fitUnEdited(MRSCont);
+elseif MRSCont.flags.isMEGA
+    [MRSCont] = osp_fitMEGA(MRSCont, basisSet);
+elseif MRSCont.flags.isHERMES
+    [MRSCont] = osp_fitHERMES(MRSCont);
+elseif MRSCont.flags.isHERCULES
+    [MRSCont] = osp_fitHERCULES(MRSCont, basisSet);
+else
+    error('No flag set for sequence type!');
+end
+
+%% Perform water reference and short-TE water fit
+
+% If water reference exists, fit it
+if MRSCont.flags.hasRef
+    refFitTime = tic;
+    reverseStr = '';
+    % Loop over all the datasets here
+    for kk = 1:MRSCont.nDatasets
+        msg = sprintf('Fitting water reference from dataset %d out of %d total datasets...\n', kk, MRSCont.nDatasets);
+        fprintf([reverseStr, msg]);
+        reverseStr = repmat(sprintf('\b'), 1, length(msg));
+        [MRSCont] = osp_fitWater(MRSCont, kk, 'ref');
+    end
+    fprintf('... done.\n');
+    toc(refFitTime);
+end
+
+% If short TE water reference exists, fit it
+if MRSCont.flags.hasWater
+    waterFitTime = tic;
+    reverseStr = '';
+    % Loop over all the datasets here
+    for kk = 1:MRSCont.nDatasets
+        msg = sprintf('Fitting short-TE water from dataset %d out of %d total datasets...\n', kk, MRSCont.nDatasets);
+        fprintf([reverseStr, msg]);
+        reverseStr = repmat(sprintf('\b'), 1, length(msg));
+        [MRSCont] = osp_fitWater(MRSCont, kk, 'w');
+    end
+    fprintf('... done.\n');
+    toc(waterFitTime);
+end
+
+%% Clean up and save
+% Set exit flags
+MRSCont.flags.didFit           = 1;
+
+end

--- a/fit/osp_fitUnEdited.m
+++ b/fit/osp_fitUnEdited.m
@@ -1,0 +1,64 @@
+function [MRSCont] = osp_fitUnEdited(MRSCont)
+%% [MRSCont] = osp_fitUnEdited(MRSCont)
+%   This function performs spectral fitting of unedited MRS data.
+%
+%   USAGE:
+%       [MRSCont] = osp_fitUnEdited(MRSCont, basisSet);
+%
+%   INPUTS:
+%       MRSCont     = Osprey MRS data container.
+%       basisSet    = Osprey basis set container.
+%
+%   OUTPUTS:
+%       MRSCont     = Osprey MRS data container.
+%
+%   AUTHOR:
+%       Dr. Georg Oeltzschner (Johns Hopkins University, 2019-04-12)
+%       goeltzs1@jhmi.edu
+%
+%   CREDITS:
+%       This code is based on numerous functions from the FID-A toolbox by
+%       Dr. Jamie Near (McGill University)
+%       https://github.com/CIC-methods/FID-A
+%       Simpson et al., Magn Reson Med 77:23-33 (2017)
+%
+%   HISTORY:
+%       2019-04-12: First version of the code.
+
+
+% Loop over all the datasets here
+metFitTime = tic;
+reverseStr = '';
+for kk = 1:MRSCont.nDatasets
+    msg = sprintf('Fitting metabolite spectra from dataset %d out of %d total datasets...\n', kk, MRSCont.nDatasets);
+    fprintf([reverseStr, msg]);
+    reverseStr = repmat(sprintf('\b'), 1, length(msg));
+    
+    % Apply scaling factor to the data
+    dataToFit   = MRSCont.processed.A{kk};
+    dataToFit   = op_ampScale(dataToFit, 1/MRSCont.fit.scale{kk});
+    % Extract fit options
+    fitOpts     = MRSCont.opts.fit;
+    fitModel    = fitOpts.method;
+    
+    % Call the fit function
+    basisSet            = MRSCont.fit.basisSet;
+    [fitParams, resBasisSet] = fit_runFit(dataToFit, basisSet, fitModel, fitOpts);
+    % [x, ampl, spl_pos, resBasisSet]  = fit_runFit(dataToFit, basisSet, fitOpts);
+    %[x, ampl, spl_pos, resBasisSet]  = fit_runFit_firstGuess(dataToFit, basisSet, fitOpts);
+    %[x, ampl, spl_pos, resBasisSet]  = fit_runFit_LCModel(dataToFit, basisSet, fitOpts);
+    
+    % Save back the basis set and fit parameters to MRSCont
+    MRSCont.fit.basisSet                    = basisSet;
+    MRSCont.fit.resBasisSet.off             = resBasisSet;
+    MRSCont.fit.results.off.fitParams{kk}   = fitParams;
+    
+    %% end time counter
+    if isequal(kk, MRSCont.nDatasets)
+        fprintf('... done.\n');
+        toc(metFitTime);
+    end
+end
+
+
+end

--- a/fit/osp_fitWater.m
+++ b/fit/osp_fitWater.m
@@ -1,0 +1,71 @@
+function [MRSCont] = osp_fitWater(MRSCont, kk, fitWhich)
+%% [MRSCont] = LCG_fitWater(MRSCont)
+%   This function initializes and runs fitting of the water reference and
+%   short-TE water scans.
+%
+%   USAGE:
+%       [MRSCont] = osp_fitWater(MRSCont, fitWhich);
+%
+%   INPUTS:
+%       MRSCont     = Osprey MRS data container.
+%       kk          = Index of the cell containing the spectrum to be fit.
+%       fitWhich    = String determining whether this function is performed
+%                     on the water reference or the short-TE water scan.
+%                     OPTIONS: - 'ref', 'w'
+%
+%   OUTPUTS:
+%       MRSCont     = Osprey MRS data container.
+%
+%   AUTHOR:
+%       Dr. Georg Oeltzschner (Johns Hopkins University, 2019-04-09)
+%       goeltzs1@jhmi.edu
+%
+%   CREDITS:
+%       This code is based on numerous functions from the FID-A toolbox by
+%       Dr. Jamie Near (McGill University)
+%       https://github.com/CIC-methods/FID-A
+%       Simpson et al., Magn Reson Med 77:23-33 (2017)
+%
+%   HISTORY:
+%       2019-04-09: First version of the code.
+
+% Close any remaining open figures
+close all;
+
+% Find the basis set index corresponding to water
+basisSet            = MRSCont.fit.basisSet;
+h2o_idx = find(strcmp(basisSet.name, 'H2O'));
+idx_toKeep = zeros(basisSet.nMets + basisSet.nMM,1);
+idx_toKeep(h2o_idx) = 1;
+
+% Remove the name, the FIDs and the specs of everything but water
+% from the basis set.
+basisSet.name   = basisSet.name(logical(idx_toKeep));
+basisSet.fids   = basisSet.fids(:,logical(idx_toKeep),:);
+basisSet.specs  = basisSet.specs(:,logical(idx_toKeep),:);
+basisSet.nMets  = 1; basisSet.nMM = 0;
+
+%%  Construct the basis functions and the spectrum that is to be fit.
+% Apply scaling factor to the data
+dataToFit       = MRSCont.processed.(fitWhich){kk};
+dataToFit       = op_ampScale(dataToFit, 1/MRSCont.fit.scale{kk});
+% Extract fit options
+fitOpts     = MRSCont.opts.fit;
+fitModel    = fitOpts.method;
+
+% Call the fit function
+[fitParamsWater, resBasisSetWater]  = fit_runFitWater(dataToFit, basisSet, fitModel, fitOpts);
+        
+%% Save back the fit parameters to MRSCont
+% Discern whether the reference or the short-TE water scan was selected
+switch fitWhich
+    case 'ref'
+        str = 'ref';
+    case 'w'
+        str = 'w';
+end
+% Write
+MRSCont.fit.resBasisSet.water      = resBasisSetWater;
+MRSCont.fit.results.(str).fitParams{kk}   = fitParamsWater;
+        
+end

--- a/libraries/FID-A/fitTools/fit_createMetabList.m
+++ b/libraries/FID-A/fitTools/fit_createMetabList.m
@@ -1,0 +1,63 @@
+% fit_createMetabList.m
+% Georg Oeltzschner, Johns Hopkins University 2019.
+%
+% USAGE:
+% metabList = fit_createMetabList;
+% 
+% DESCRIPTION:
+% Creates a list of metabolite basis functions that are to be included in 
+% a fit.
+% 
+% OUTPUTS:
+% metabList = structure including flags (1 = included, 0 = excluded) for
+%             each metabolite included in the FID-A spin system definition,
+%             plus various MM basis functions that may have been included
+%             with fit_makeBasis.
+%
+% INPUTS:
+% NONE
+
+function metabList = fit_createMetabList
+
+% Select metabolites to include in basis set
+metabList.Ala      = 0;
+metabList.Asc      = 1;
+metabList.Asp      = 1;
+metabList.bHB      = 0;
+metabList.bHG      = 0;
+metabList.Cit      = 0;
+metabList.Cr       = 1;
+metabList.CrCH2    = 1;
+metabList.EtOH     = 0;
+metabList.GABA     = 1;
+metabList.GPC      = 1;
+metabList.GSH      = 1;
+metabList.Glc      = 0;
+metabList.Gln      = 1;
+metabList.Glu      = 1;
+metabList.Gly      = 0;
+metabList.H2O      = 1;
+metabList.Ins      = 1;
+metabList.Lac      = 1;
+metabList.NAA      = 1;
+metabList.NAAG     = 1;
+metabList.PCh      = 1;
+metabList.PCr      = 1;
+metabList.PE       = 1;
+metabList.Phenyl   = 0;
+metabList.Scyllo   = 1;
+metabList.Ser      = 0;
+metabList.Tau      = 1;
+metabList.Tyros    = 0;
+
+% Select MM/lipid basis functions to include
+metabList.MM09     = 1;
+metabList.MM12     = 1;
+metabList.MM14     = 1;
+metabList.MM17     = 1;
+metabList.MM20     = 1;
+metabList.Lip09    = 1;
+metabList.Lip13    = 1;
+metabList.Lip20    = 1;
+
+end

--- a/libraries/FID-A/fitTools/fit_resampleBasis.m
+++ b/libraries/FID-A/fitTools/fit_resampleBasis.m
@@ -29,14 +29,17 @@ function [resBasisSet] = fit_resampleBasis(dataToFit, basisSet)
 
 
 % Determine the ppm ranges of both the data and the basis functions.
-ppmRangeData        = dataToFit.ppm;
+ppmRangeData        = dataToFit.ppm';
 ppmRangeBasis       = basisSet.ppm;
 ppmIsInDataRange    = (ppmRangeBasis < ppmRangeData(1)) & (ppmRangeBasis > ppmRangeData(end));
+if sum(ppmIsInDataRange) == 0
+    ppmIsInDataRange    = (ppmRangeBasis > ppmRangeData(1)) & (ppmRangeBasis < ppmRangeData(end));
+end
 
 % Now resample the basis functions to match the resolution and frequency
 % range (ppm axis) of the data.
-fids_interp     = zeros(length(ppmIsInDataRange), (basisSet.nMets + basisSet.nMM)); % allocate memory
-specs_interp    = zeros(length(ppmIsInDataRange), (basisSet.nMets + basisSet.nMM)); % allocate memory
+fids_interp     = zeros(length(ppmRangeData), (basisSet.nMets + basisSet.nMM)); % allocate memory
+specs_interp    = zeros(length(ppmRangeData), (basisSet.nMets + basisSet.nMM)); % allocate memory
 % Loop over the number of basis functions (i.e. metabolites and
 % MM/lipids)
 for ll=1:(basisSet.nMets + basisSet.nMM)
@@ -60,6 +63,8 @@ resBasisSet.ppm     = ppmRangeData;
 resBasisSet.specs   = specs_interp;
 resBasisSet.fids    = fids_interp;
 resBasisSet.sz      = size(resBasisSet.fids);
+resBasisSet.n       = length(resBasisSet.fids);
+
 % Calculate the new spectral width and dwelltime:
 dppm                        = abs(resBasisSet.ppm(2)-resBasisSet.ppm(1));
 ppmrange                    = abs((resBasisSet.ppm(end)-resBasisSet.ppm(1)))+dppm;

--- a/libraries/FID-A/fitTools/fit_runFit.m
+++ b/libraries/FID-A/fitTools/fit_runFit.m
@@ -1,0 +1,69 @@
+% fit_runFit.m
+% Georg Oeltzschner, Johns Hopkins University 2019.
+%
+% USAGE:
+% [fitParams, resBasisSet] = fit_runFit(dataToFit, basisSet, fitModel, fitOpts);
+% 
+% DESCRIPTION:
+% This function performs spectral fitting of the data in dataToFit, using
+% the basis set in basisSet, using a set of options defined in fitOpts.
+%
+% Prior to handing over the data and the basis set to the model function,
+% the basis set is resampled to match the spectral resolution of the data.
+%
+% The function 'fitModel' describes the actual fitting process that is
+% being performed. The workflow is designed to encourage development and
+% easy testing/implementation of new quantitative models.
+% 
+% OUTPUTS:
+% fitParams   = Structure containing all necessary fit parameters
+%               (model-dependent)
+% resBasisSet = resampled basis set (to match the spectral data resolution)
+%
+% INPUTS:
+% dataToFit   = FID-A data structure
+% basisSet    = FID-A basis set container
+% fitModel    = Function containing the fitting model
+% fitOpts     = Structure containing fit options
+
+function [fitParams, resBasisSet] = fit_runFit(dataToFit, basisSet, fitModel, fitOpts)
+
+% Parse input arguments
+if nargin<4
+    fitOpts = fit_defaultFitOpts(fitModel);
+end
+
+%%% 1. PREPARE BASIS SET %%%
+% Resample basis set to match data resolution and frequency range
+resBasisSet             = fit_resampleBasis(dataToFit, basisSet);
+
+
+%%% 2. SELECT THE MODEL %%%
+switch fitModel
+    case 'Osprey'
+        [fitParams] = fit_Osprey(dataToFit, resBasisSet, fitOpts);
+end
+
+end
+
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+function fitOpts = fit_defaultFitOpts(fitModel)
+
+% Depending on the model chosen, set some default values here
+
+switch fitModel
+    case 'Osprey'
+        % Determine fitting range (in ppm) for the metabolite and water spectra
+        fitOpts.range              = [0.2 4.2];        % [ppm] Default: [0.2 4.2]
+        fitOpts.rangeWater         = [2.0 7.4];        % [ppm] Default: [2.0 7.4]
+        
+        % Determine the baseline knot spacing (in ppm) for the metabolite spectra
+        fitOpts.bLineKnotSpace     = 0.4;              % [ppm] Default: 0.4.
+end
+
+end

--- a/libraries/FID-A/fitTools/fit_runFitWater.m
+++ b/libraries/FID-A/fitTools/fit_runFitWater.m
@@ -1,0 +1,61 @@
+% fit_runFitWater.m
+% Georg Oeltzschner, Johns Hopkins University 2019.
+%
+% USAGE:
+% [fitParams, resBasisSet] = fit_runFitWater(dataToFit, basisSet, fitModel, fitOpts);
+% 
+% DESCRIPTION:
+% This function performs spectral fitting of the water data in dataToFit, using
+% the water basis function in basisSet, using a set of options defined in fitOpts.
+% 
+% Prior to handing over the data and the basis set to the model function,
+% the basis set is resampled to match the spectral resolution of the data.
+%
+% The function 'fitModel' describes the actual fitting process that is
+% being performed. The workflow is designed to encourage development and
+% easy testing/implementation of new quantitative models.
+%
+% OUTPUTS:
+% fitParamsWater    = Structure containing all necessary fit parameters
+%                       (model-dependent)
+% resBasisSet       = resampled basis set (to match the spectral data resolution)
+%
+% INPUTS:
+% dataToFit   = FID-A water data structure
+% basisSet    = FID-A water basis set container
+% fitModel    = Function containing the water fitting model
+% fitOpts     = Structure containing fit options
+
+function [fitParamsWater, resBasisSet] = fit_runFitWater(dataToFit, basisSet, fitModel, fitOpts)
+
+% Parse input arguments
+if nargin<4
+    fitOpts = fit_defaultFitOpts;
+end
+
+%%% 1. PREPARE DATA AND BASIS SETS %%%
+% Resample basis set to match data resolution and frequency range
+resBasisSet             = fit_resampleBasis(dataToFit, basisSet);
+
+
+%%% 2. SELECT THE MODEL %%%
+switch fitModel
+    case 'Osprey'
+        [fitParamsWater] = fit_waterOsprey(dataToFit, resBasisSet, fitOpts);
+end
+
+
+end
+
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+function fitOpts = fit_defaultFitOpts
+
+% Determine fitting range (in ppm) for the water spectra
+fitOpts.rangeWater         = [2.0 7.4];        % [ppm] Default: [2.0 7.4]
+
+end

--- a/libraries/FID-A/fitTools/fit_selectMetabs.m
+++ b/libraries/FID-A/fitTools/fit_selectMetabs.m
@@ -1,0 +1,87 @@
+% fit_selectMetabs.m
+% Georg Oeltzschner, Johns Hopkins University 2019.
+%
+% USAGE:
+% basisSetOut = fit_selectMetabs(basisSetIn, metabList, fitMM)
+% 
+% DESCRIPTION:
+% This function loads the basis set functions for the metabolites
+% that have a positive flag set in the structure metabList, which has
+% previously been created with fit_createMetabList.
+%
+% Only basis functions for the metabolites selected in fit_createMetabList
+% will be included. This function will output a modified FID-A basis
+% set container, which will be subsequently passed on to the fitting
+% algorithm.
+%
+% The function will also include MM and lipid spectra, if present in
+% the basis set, and if they were selected to be included.
+%
+% The other basis functions will be discarded.
+% 
+% OUTPUTS:
+% basisSetOut = FID-A basis set container that only contains the basis
+%               functions specified in metabList
+%
+% INPUTS:
+% basisSetIn  = FID-A basis set container (created with fit_makeBasis).
+% metabList   = Structure (created with fit_createMetabList) containing
+%               flags for each metabolite/MM/lipid basis function that is 
+%               supposed to be included in the basis set.
+% fitMM       = Flag determining whether MM/lipid basis functions are being
+%               kept in the output basis set. 1 = Yes (default), 0 = No.
+
+function basisSetOut = fit_selectMetabs(basisSetIn, metabList, fitMM)
+
+% Parse input arguments
+if nargin<3
+    fitMM = 1;
+end
+% Save all available metabolite names in a cell
+all_mets = {'Ala','Asc','Asp','bHB','bHG','Cit','Cr','CrCH2','EtOH','GABA','GPC','GSH','Glc','Gln' ...
+    ,'Glu','Gly','H2O','Ins','Lac','NAA','NAAG','PCh','PCr','PE','Phenyl' ...
+    ,'Scyllo','Ser','Tau','Tyros'};
+
+% Duplicate the input basis set
+basisSetOut = basisSetIn;
+
+% Check which metabolites are available in the basis set
+metsInBasisSet = basisSetIn.name;
+[metsToKeep,~,~] = intersect(metsInBasisSet, all_mets, 'stable');
+
+% Check for each remaining metabolite in the basis set whether it has been 
+% flagged to be included in the basis set in osp_FitInitialise.m:
+idx_toKeep = zeros(length(metsToKeep),1);
+for kk = 1:length(metsToKeep)
+    if ~metabList.(metsToKeep{kk})
+        idx_toKeep(kk) = 0;
+    else
+        idx_toKeep(kk) = 1;
+    end
+end
+basisSetOut.nMets = sum(idx_toKeep);
+
+% If the flag for including MM/lipid basis functions is set in osp_FitInitialise,
+% include them now
+all_MMs = {'MM09','MM12','MM14','MM17','MM20','Lip09','Lip13','Lip20'};
+% Check which of these are available in the basis set
+MMsInBasisSet = basisSetIn.name;
+[MMsToKeep,~,~] = intersect(MMsInBasisSet, all_MMs, 'stable');
+if fitMM
+    idx_toKeepMM = ones(length(MMsToKeep),1);
+else
+    idx_toKeepMM = zeros(length(MMsToKeep),1);
+end
+
+idx_toKeep = [idx_toKeep; idx_toKeepMM];
+basisSetOut.nMM = sum(idx_toKeepMM);
+
+
+% If the flag is set to zero, remove the name, the FIDs and the specs
+% from the basis set. Also update the numbers for metabolite and MM/lipid
+% basis functions
+basisSetOut.name   = basisSetOut.name(logical(idx_toKeep));
+basisSetOut.fids   = basisSetOut.fids(:,logical(idx_toKeep),:);
+basisSetOut.specs  = basisSetOut.specs(:,logical(idx_toKeep),:);
+
+end


### PR DESCRIPTION
Adding the fitting framework. Include the OspreyFit module, functions to fit unedited and water data. Include all necessary fit tools (following FID-A convention). Some changes to osp_plotFit to accommodate the generic framework, allowing users to add their own models.