### PR TITLE
Phasing Siemens and frequency drift 

### DIFF
--- a/libraries/FID-A/processingTools/op_creChoFit.m
+++ b/libraries/FID-A/processingTools/op_creChoFit.m
@@ -59,11 +59,13 @@ x0 = [Area Width maxFreq 0 Baseline 0 1];
 % Set up the least-squares and non-linear solvers
 lsqopts = optimset('lsqcurvefit');
 lsqopts = optimset(lsqopts,'MaxIter',800,'TolX',1e-4,'TolFun',1e-4,'Display','off');
+lb = [0 x0(2)*0.00001 x0(3)-0.42];
+ub = [x0(1)*10000 x0(2)*2 x0(3)+0.58];
 nlinopts = statset('nlinfit');
 nlinopts = statset(nlinopts,'MaxIter',400,'TolX',1e-6,'TolFun',1e-6);
 
 % Set up the fit problem and solve it
-x0 = lsqcurvefit(@TwoLorentzModel, x0, ppm(freqLim)', real(specRange), [], [], lsqopts);
+x0 = lsqcurvefit(@TwoLorentzModel, x0, ppm(freqLim)', real(specRange), lb, ub, lsqopts);
 [parsFit, residCr] = nlinfit(ppm(freqLim)', specRange, @TwoLorentzModel, x0, nlinopts);
 
 % Optional plotting of data and results

--- a/process/osp_processUnEdited.m
+++ b/process/osp_processUnEdited.m
@@ -110,9 +110,18 @@ for kk = 1:MRSCont.nDatasets
     raw     = op_fddccorr(raw,100);                                     % Correct back to baseline
     
     
-    %%% 6. REFERENCE SPECTRUM CORRECTLY TO FREQUENCY AXIS
+    %%% 6. REFERENCE SPECTRUM CORRECTLY TO FREQUENCY AXIS AND PHASE SIEMENS
+    %%% DATA
     [raw, refShift]             = op_ppmref(raw,1.9,2.1,2.008);             % Reference to NAA @ 2.008 ppm
-    MRSCont.processed.A{kk}     = raw;                                      % Save back to MRSCont container
+                                      % Save back to MRSCont container
+    
+    if strcmp(MRSCont.vendor,'Siemens')
+    % Fit a double-Lorentzian to the Cr-Cho area, and phase the spectrum
+    % with the negative phase of that fit
+    [raw,~]       = op_phaseCrCho(raw, 1);
+    end
+    
+    MRSCont.processed.A{kk}     = raw;   
     
     
     %%% 7. GET SHORT-TE WATER DATA %%%
@@ -136,7 +145,7 @@ for kk = 1:MRSCont.nDatasets
     MRSCont.QM.SNR.A(kk)    = op_getSNR(MRSCont.processed.A{kk}); % NAA amplitude over noise floor
     FWHM_Hz                 = op_getLW(MRSCont.processed.A{kk},1.8,2.2); % in Hz
     MRSCont.QM.FWHM.A(kk)   = FWHM_Hz./MRSCont.processed.A{kk}.txfrq*1e6; % convert to ppm
-    MRSCont.QM.drift.A(:,kk)= driftPre;
+    MRSCont.QM.drift.A{kk}= driftPre;
     MRSCont.QM.freqShift.A(kk) = refShift;
     
     if MRSCont.flags.hasRef

--- a/process/osp_processUnEdited.m
+++ b/process/osp_processUnEdited.m
@@ -113,14 +113,13 @@ for kk = 1:MRSCont.nDatasets
     %%% 6. REFERENCE SPECTRUM CORRECTLY TO FREQUENCY AXIS AND PHASE SIEMENS
     %%% DATA
     [raw, refShift]             = op_ppmref(raw,1.9,2.1,2.008);             % Reference to NAA @ 2.008 ppm
-                                      % Save back to MRSCont container
-    
+                                      
+    % Save back to MRSCont container
     if strcmp(MRSCont.vendor,'Siemens')
-    % Fit a double-Lorentzian to the Cr-Cho area, and phase the spectrum
-    % with the negative phase of that fit
-    [raw,~]       = op_phaseCrCho(raw, 1);
+        % Fit a double-Lorentzian to the Cr-Cho area, and phase the spectrum
+        % with the negative phase of that fit
+        [raw,~]       = op_phaseCrCho(raw, 1);
     end
-    
     MRSCont.processed.A{kk}     = raw;   
     
     


### PR DESCRIPTION
Additional phasing step is added to resolve phasing issues with Siemens data. Constraints added to the Least-squares solver to restrict amplitude and frequency range to improve inital guess x0 for the non-linear solver.

Cell array is added for frequency drift to resolve different numbers of averages.