### PR TITLE
Add edit target specification

### DIFF
--- a/exampledata/ima/jobIMA.m
+++ b/exampledata/ima/jobIMA.m
@@ -68,10 +68,19 @@
 %%% 1. SPECIFY SEQUENCE INFORMATION %%%
 
 % Specify sequence type
-seqType = 'MEGA';           % OPTIONS:    - 'unedited' (default)
+seqType = 'MEGA';               % OPTIONS:    - 'unedited' (default)
                                 %             - 'MEGA'
                                 %             - 'HERMES'
                                 %             - 'HERCULES'
+                                
+% Specify editing targets
+editTarget = 'GABA';            % OPTIONS:    - 'none' (default if 'unedited')
+                                %             - 'GABA', 'GSH'
+                                %               (for 'MEGA')
+                                %             - 'GABA_GSH', 'GABA_GSH_EtOH'
+                                %               (for 'HERMES')
+                                %             - 'HERCULES1', 'HERCULES2'
+                                %               (for 'HERCULES')
                                 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/exampledata/p/jobP.m
+++ b/exampledata/p/jobP.m
@@ -71,6 +71,15 @@ seqType = 'unedited';           % OPTIONS:    - 'unedited' (default)
                                 %             - 'MEGA'
                                 %             - 'HERMES'
                                 %             - 'HERCULES'
+
+% Specify editing targets
+editTarget = 'none';            % OPTIONS:    - 'none' (default if 'unedited')
+                                %             - 'GABA', 'GSH'
+                                %               (for 'MEGA')
+                                %             - 'GABA_GSH', 'GABA_GSH_EtOH'
+                                %               (for 'HERMES')
+                                %             - 'HERCULES1', 'HERCULES2'
+                                %               (for 'HERCULES')
                                 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/exampledata/rda/jobRDA.m
+++ b/exampledata/rda/jobRDA.m
@@ -72,6 +72,15 @@ seqType = 'unedited';           % OPTIONS:    - 'unedited' (default)
                                 %             - 'MEGA'
                                 %             - 'HERMES'
                                 %             - 'HERCULES'
+
+% Specify editing targets
+editTarget = 'none';            % OPTIONS:    - 'none' (default if 'unedited')
+                                %             - 'GABA', 'GSH'
+                                %               (for 'MEGA')
+                                %             - 'GABA_GSH', 'GABA_GSH_EtOH'
+                                %               (for 'HERMES')
+                                %             - 'HERCULES1', 'HERCULES2'
+                                %               (for 'HERCULES')
                                 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/exampledata/sdat/jobSDAT.m
+++ b/exampledata/sdat/jobSDAT.m
@@ -71,6 +71,15 @@ seqType = 'unedited';           % OPTIONS:    - 'unedited' (default)
                                 %             - 'MEGA'
                                 %             - 'HERMES'
                                 %             - 'HERCULES'
+
+% Specify editing targets
+editTarget = 'none';            % OPTIONS:    - 'none' (default if 'unedited')
+                                %             - 'GABA', 'GSH'
+                                %               (for 'MEGA')
+                                %             - 'GABA_GSH', 'GABA_GSH_EtOH'
+                                %               (for 'HERMES')
+                                %             - 'HERCULES1', 'HERCULES2'
+                                %               (for 'HERCULES')
                                 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/exampledata/sdat/jobSDAT_MEGA.m
+++ b/exampledata/sdat/jobSDAT_MEGA.m
@@ -67,10 +67,19 @@
 %%% 1. SPECIFY SEQUENCE INFORMATION %%%
 
 % Specify sequence type
-seqType = 'MEGA';           % OPTIONS:    - 'unedited' (default)
+seqType = 'MEGA';               % OPTIONS:    - 'unedited' (default)
                                 %             - 'MEGA'
                                 %             - 'HERMES'
                                 %             - 'HERCULES'
+                                
+% Specify editing targets
+editTarget = 'GABA';            % OPTIONS:    - 'none' (default if 'unedited')
+                                %             - 'GABA', 'GSH'
+                                %               (for 'MEGA')
+                                %             - 'GABA_GSH', 'GABA_GSH_EtOH'
+                                %               (for 'HERMES')
+                                %             - 'HERCULES1', 'HERCULES2'
+                                %               (for 'HERCULES')
                                 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/exampledata/twix/jobTwix.m
+++ b/exampledata/twix/jobTwix.m
@@ -71,7 +71,16 @@ seqType = 'unedited';           % OPTIONS:    - 'unedited' (default)
                                 %             - 'MEGA'
                                 %             - 'HERMES'
                                 %             - 'HERCULES'
-                                
+
+% Specify editing targets
+editTarget = 'none';            % OPTIONS:    - 'none' (default if 'unedited')
+                                %             - 'GABA', 'GSH'
+                                %               (for 'MEGA')
+                                %             - 'GABA_GSH', 'GABA_GSH_EtOH'
+                                %               (for 'HERMES')
+                                %             - 'HERCULES1', 'HERCULES2'
+                                %               (for 'HERCULES')
+                               
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
@@ -99,7 +108,7 @@ opts.fit.method             = 'Osprey';       % OPTIONS:  - 'Osprey' (default)
 
 % Choose the fitting style for difference-edited datasets (MEGA, HERMES, HERCULES)
 % (only available for the Osprey fitting method)
-opts.fit.style              = 'Concatenated';   % OPTIONS:  - 'Concatenated' (default) - will fit DIFF and SUM simultaneously)
+opts.fit.style              = 'Separate';   % OPTIONS:  - 'Concatenated' (default) - will fit DIFF and SUM simultaneously)
                                                 %           - 'Separate' - will fit DIFF and OFF separately
 
 % Determine fitting range (in ppm) for the metabolite and water spectra

--- a/fit/osp_fitInitialise.m
+++ b/fit/osp_fitInitialise.m
@@ -22,22 +22,28 @@ function [MRSCont] = osp_fitInitialise(MRSCont)
 % Find the right basis set (provided as *.mat file in Osprey basis set
 % format)
 if MRSCont.flags.isUnEdited
+    % Extract TE from first dataset
+    te = num2str(MRSCont.raw{1}.te);
     switch MRSCont.vendor
         case 'Philips'
-            MRSCont.opts.fit.basisSetFile        = which('fit/basissets/philips/press35/basis_philips_press35.mat'); 
+            MRSCont.opts.fit.basisSetFile        = which(['fit/basissets/philips/press' te '/basis_philips_press' te '.mat']); 
         case 'GE'
-            MRSCont.opts.fit.basisSetFile        = which('fit/basissets/ge/press35/basis_ge_press35.mat'); 
+            MRSCont.opts.fit.basisSetFile        = which(['fit/basissets/ge/press' te '/basis_ge_press' te '.mat']); 
         case 'Siemens'
-            MRSCont.opts.fit.basisSetFile        = which('fit/basissets/siemens/press35/basis_siemens_press35.mat'); 
+            MRSCont.opts.fit.basisSetFile        = which(['fit/basissets/siemens/press' te '/basis_siemens_press' te '.mat']); 
     end
 elseif MRSCont.flags.isMEGA
+    % Extract edit target from MRSCont
+    editTarget = lower(MRSCont.opts.editTarget);
+    % Extract TE from first dataset
+    te = num2str(MRSCont.raw{1}.te);
     switch MRSCont.vendor
         case 'Philips'
-            MRSCont.opts.fit.basisSetFile        = which('fit/basissets/philips/megapress68/basis_philips_megapress68.mat');
+            MRSCont.opts.fit.basisSetFile        = which(['fit/basissets/philips/megapress_' editTarget te '/basis_philips_megapress_' editTarget te '.mat']);
         case 'GE'
-            MRSCont.opts.fit.basisSetFile        = which('fit/basissets/GE/MP_GABA/BASIS_noMM.mat');
+            MRSCont.opts.fit.basisSetFile        = which(['fit/basissets/ge/megapress_' editTarget te '/basis_ge_megapress_' editTarget te '.mat']);
         case 'Siemens'
-            MRSCont.opts.fit.basisSetFile        = which('fit/basissets/siemens/megapress68/basis_siemens_megapress68.mat');
+            MRSCont.opts.fit.basisSetFile        = which(['fit/basissets/siemens/megapress_' editTarget te '/basis_siemens_megapress_' editTarget te '.mat']);
     end
 elseif MRSCont.flags.isHERMES
     switch MRSCont.vendor

--- a/job/OspreyJob.m
+++ b/job/OspreyJob.m
@@ -93,6 +93,12 @@ if strcmp(jobFileFormat,'csv')
         fprintf('Sequence type is set to unedited (default). Please indicate otherwise in the csv-file or the GUI \n');
         seqType = 'unedited';
     end
+    if isfield(jobStruct,'editTarget')
+        opts.editTarget = jobStruct(1).editTarget;
+    else
+        fprintf('Editing target is set to none (default). Please indicate otherwise in the csv-file or the GUI \n');
+        opts.editTarget = 'unedited';
+    end
     if isfield(jobStruct,'saveLCM')
         opts.saveLCM = jobStruct(1).saveLCM;
     else
@@ -154,12 +160,16 @@ end
 switch seqType
     case 'unedited'
         MRSCont.flags.isUnEdited    = 1;
+        opts.editTarget             = 'none';
     case 'MEGA'
         MRSCont.flags.isMEGA        = 1;
+        opts.editTarget             = editTarget;
     case 'HERMES'
         MRSCont.flags.isHERMES      = 1;
+        opts.editTarget             = editTarget;
     case 'HERCULES'
         MRSCont.flags.isHERCULES    = 1;
+        opts.editTarget             = editTarget;
     otherwise
         error('Invalid job file! seqType must be ''unedited'', ''MEGA'', ''HERMES'', or ''HERCULES''.');
 end
@@ -221,12 +231,21 @@ if length(isUnique) ~= 1
 end
 
 
-%%% 6. SET FLAGS %%%
+%%% 6. SET UP DEFAULT OSPREY COLORMAP %%%
+% Default colormap
+colormap.Background     = [255/255 254/255 254/255];
+colormap.LightAccent    = [110/255 136/255 164/255];
+colormap.Foreground     = [11/255 71/255 111/255];
+colormap.Accent         = [11/255 71/255 111/255];
+MRSCont.colormap        = colormap;
+
+
+%%% 7. SET FLAGS %%%
 MRSCont.flags.didLoadJob    = 1;
 MRSCont.loadedJob           = jobFile;
 
 
-%%% 7. CHECK IF OUTPUT STRUCTURE ALREADY EXISTS IN OUTPUT FOLDER %%%
+%%% 8. CHECK IF OUTPUT STRUCTURE ALREADY EXISTS IN OUTPUT FOLDER %%%
 [~,jobfilename,jobfileext]  = fileparts(jobFile);
 outputFile                  = strrep([jobfilename jobfileext], jobfileext, '.mat');
 MRSCont.outputFile          = outputFile;


### PR DESCRIPTION
Add a new field in job files to define the target molecule of an editing experiment. Include code to parse this option in OspreyJob and osp_fitInitialise, so that the appropriate basis function is selected upon fitting. Update all example job files accordingly.