### PR TITLE
New Preprocessing

### DIFF
--- a/process/OspreyProcess.m
+++ b/process/OspreyProcess.m
@@ -47,19 +47,31 @@ else
     error('No flag set for sequence type!');
 end
 
-% Gather some more information from the processed data
+% Gather some more information from the processed data   y(isnan(y(1:end-1))) = [];
 SubSpecNames = fieldnames(MRSCont.processed);
 NoSubSpec = length(fieldnames(MRSCont.processed));
 for ss = 1 : NoSubSpec
     for kk = 1 : MRSCont.nDatasets
             temp_sz(1,kk)= MRSCont.processed.(SubSpecNames{ss}){1,kk}.sz(1);
+            temp_sw(1,kk)= MRSCont.processed.(SubSpecNames{ss}){1,kk}.spectralwidth;
     end
     [MRSCont.info.(SubSpecNames{ss}).unique_ndatapoint,MRSCont.info.(SubSpecNames{ss}).unique_ndatapoint_ind,MRSCont.info.(SubSpecNames{ss}).unique_ndatapoint_indsort]  = unique(temp_sz,'Stable');
     [MRSCont.info.(SubSpecNames{ss}).max_ndatapoint,MRSCont.info.(SubSpecNames{ss}).max_ndatapoint_ind] = max(temp_sz);
+    temp_sw_store = temp_sw;
+    for np = 1 : length(MRSCont.info.(SubSpecNames{ss}).unique_ndatapoint)
+        [max_ind] = find(temp_sz==MRSCont.info.(SubSpecNames{ss}).unique_ndatapoint(np));
+        temp_sw(max_ind) = nan;
+        [MRSCont.info.(SubSpecNames{ss}).unique_spectralwidth{np},MRSCont.info.(SubSpecNames{ss}).unique_spectralwidth_ind{np},~]  = unique(temp_sw,'Stable');
+        nanind = isnan(MRSCont.info.(SubSpecNames{ss}).unique_spectralwidth{np});
+        MRSCont.info.(SubSpecNames{ss}).unique_spectralwidth{np}(isnan(MRSCont.info.(SubSpecNames{ss}).unique_spectralwidth{np}(1:end))) = [];
+        MRSCont.info.(SubSpecNames{ss}).unique_spectralwidth_ind{np}(nanind ==1) = [];
+        temp_sw = temp_sw_store;
+    end
 end
 %% Clean up and save
 % Set exit flags and reorder fields
 MRSCont.flags.didProcess           = 1;
+MRSCont.ver.Pro             = '100 Pro';
 MRSCont.processed                  = orderfields(MRSCont.processed);
 % Save the output structure to the output folder
 % Determine output folder

--- a/process/osp_CrChoReferencing.m
+++ b/process/osp_CrChoReferencing.m
@@ -1,5 +1,5 @@
-function [refShift, refFWHM] = fit_LCModelReferencing(dataToFit)
-%% [refShift, refFWHM] = fit_LCModelReferencing(dataToFit)
+function [refShift, refFWHM] = osp_CrChoReferencing(dataToFit)
+%% [refShift, refFWHM] = osp_CrChoReferencing(dataToFit)
 %   Calculates the reference shift and full-width half-maximum (FWHM) of a
 %   spectrum according to the LCModel algorithm. The algorithm is described in:
 %       S.W. Provencher, "Estimation of metabolite concentrations from
@@ -38,10 +38,10 @@ x = ppm;
 y = zeros(size(x));
 
 % Set up delta functions
-[a,b] = min((abs(x-2.01)));
+% [a,b] = min((abs(x-2.01)));
 [c,d] = min((abs(x-3.03)));
 [e,f] = min((abs(x-3.22)));
-y(b) = 1;
+% y(b) = 1;
 y(d) = 1;
 y(f) = 1;
 

--- a/process/osp_processHERCULES.m
+++ b/process/osp_processHERCULES.m
@@ -39,7 +39,7 @@ warning('off','all');
 if nargin < 2
     target1 = MRSCont.opts.editTarget{1}; 
     target2 = MRSCont.opts.editTarget{2};  
-end 
+end
 %% Loop over all datasets
 refProcessTime = tic;
 reverseStr = '';
@@ -59,39 +59,80 @@ for kk = 1:MRSCont.nDatasets
         raw_C   = op_takesubspec(raw,3);                    % Get third subspectrum
         raw_D   = op_takesubspec(raw,4);                    % Get fourth subspectrum
         
-        % Measure and save drift information
-        driftPreA    = op_measureDrift(raw_A);
-        driftPreB    = op_measureDrift(raw_B);
-        driftPreC    = op_measureDrift(raw_C);
-        driftPreD    = op_measureDrift(raw_D);
-        MRSCont.QM.drift.pre.diff1{kk}  = [driftPreA driftPreB driftPreC driftPreD];
-        MRSCont.QM.drift.pre.diff2{kk}  = [driftPreA driftPreB driftPreC driftPreD];
-        MRSCont.QM.drift.pre.sum{kk}    = [driftPreA driftPreB driftPreC driftPreD];
-        
     else
-        % Measure and save drift information
-        driftPre    = op_measureDrift(raw);
-        MRSCont.QM.drift.pre.diff1{kk}  = driftPre;
-        MRSCont.QM.drift.pre.diff2{kk}  = driftPre;
-        MRSCont.QM.drift.pre.sum{kk}    = driftPre;
-    
+
         raw_A   = op_takeaverages(raw,1:4:raw.averages);    % Get first subspectrum
         raw_B   = op_takeaverages(raw,2:4:raw.averages);    % Get second subspectrum
         raw_C   = op_takeaverages(raw,3:4:raw.averages);    % Get third subspectrum
         raw_D   = op_takeaverages(raw,4:4:raw.averages);    % Get fourth subspectrum
     end
     
+
+    temp_A = op_averaging(raw_A);
+    raw_A_Cr    = op_freqrange(temp_A,2.8,3.2);
+    % Determine the polarity of the respective peak: if the absolute of the
+    % maximum minus the absolute of the minimum is positive, the polarity 
+    % of the respective peak is positive; if the absolute of the maximum 
+    % minus the absolute of the minimum is negative, the polarity is negative.
+    polResidCr  = abs(max(real(raw_A_Cr.specs))) - abs(min(real(raw_A_Cr.specs)));
+    temp_rawA = raw_A;
+    if polResidCr < 0        
+        temp_rawA = op_ampScale(temp_rawA,-1);
+    end
+    
+    temp_B = op_averaging(raw_B);
+    raw_B_Cr    = op_freqrange(temp_B,2.8,3.2);
+    polResidCr  = abs(max(real(raw_B_Cr.specs))) - abs(min(real(raw_B_Cr.specs)));
+    temp_rawB = raw_B;
+    if polResidCr < 0        
+        temp_rawB = op_ampScale(temp_rawB,-1);
+    end
+    
+    temp_C = op_averaging(raw_C);
+    raw_C_Cr    = op_freqrange(temp_C,2.8,3.2);
+    polResidCr  = abs(max(real(raw_C_Cr.specs))) - abs(min(real(raw_C_Cr.specs)));
+    temp_rawC = raw_C;
+    if polResidCr < 0        
+        temp_rawC = op_ampScale(temp_rawC,-1);
+    end
+    
+    temp_D = op_averaging(raw_D);
+    raw_D_Cr    = op_freqrange(temp_D,2.8,3.2);
+    polResidCr  = abs(max(real(raw_D_Cr.specs))) - abs(min(real(raw_D_Cr.specs)));
+    temp_rawD = raw_D;
+    if polResidCr < 0        
+        temp_rawD = op_ampScale(temp_rawD,-1);
+    end
+    temp_proc   = op_addScans(temp_rawA,temp_rawB);
+    temp_proc   = op_addScans(temp_proc,temp_rawC);
+    temp_proc   = op_addScans(temp_proc,temp_rawD);
+    temp_spec   = temp_proc;
+    for av = 1 : round(temp_rawA.averages*0.1) :temp_rawA.averages-(round(temp_rawA.averages*0.1)-1)-mod(temp_rawA.averages,round(temp_rawA.averages*0.1))
+        fids = temp_proc.fids(:,av:av+(round(temp_rawA.averages*0.1)-1));
+        specs = temp_proc.specs(:,av:av+(round(temp_rawA.averages*0.1)-1));
+        temp_spec.fids = mean(fids,2);
+        temp_spec.specs = mean(specs,2);
+        [refShift, ~] = osp_CrChoReferencing(temp_spec);
+        refShift_ind_ini(av : av+round(temp_rawA.averages*0.1)-1) = refShift;
+    end
+    if mod(temp_rawA.averages,round(temp_rawA.averages*0.1)) > 0
+        fids = temp_proc.fids(:,end-(mod(temp_rawA.averages,round(temp_rawA.averages*0.1))-1):end);
+        specs = temp_proc.specs(:,end-(mod(temp_rawA.averages,round(temp_rawA.averages*0.1))-1):end);
+        temp_spec.fids = mean(fids,2);
+        temp_spec.specs = mean(specs,2);
+        [refShift, ~] = osp_CrChoReferencing(temp_spec);
+        refShift_ind_ini(end-(mod(temp_rawA.averages,round(temp_rawA.averages*0.1))-1) : temp_rawA.averages) = refShift;        
+    end
+    
     % Perform robust spectral correction with weighted averaging.
     % This can obviously only be done, if the spectra have not been 
     % pre-averaged, i.e. in some older RDA and DICOM files (which should, 
     % generally, not be used).
-    if ~raw.flags.averaged
-        
-        [raw_A, fs_A, phs_A, weights_A, driftPreA, driftPostA]   = op_robustSpecReg(raw_A, 'HERCULES', 0);
-        [raw_B, fs_B, phs_B, weights_B, driftPreB, driftPostB]   = op_robustSpecReg(raw_B, 'HERCULES', 0);                  
-        [raw_C, fs_C, phs_C, weights_C, driftPreC, driftPostC]   = op_robustSpecReg(raw_C, 'HERCULES', 0);                    
-        [raw_D, fs_D, phs_D, weights_D, driftPreD, driftPostD]   = op_robustSpecReg(raw_D, 'HERCULES', 0);     
-
+    if ~raw.flags.averaged       
+        [raw_A, fs_A, phs_A, weights_A, driftPreA, driftPostA]   = op_robustSpecReg(raw_A, 'HERMES', 0,refShift_ind_ini);
+        [raw_B, fs_B, phs_B, weights_B, driftPreB, driftPostB]   = op_robustSpecReg(raw_B, 'HERMES', 0, refShift_ind_ini);                  
+        [raw_C, fs_C, phs_C, weights_C, driftPreC, driftPostC]   = op_robustSpecReg(raw_C, 'HERMES', 0, refShift_ind_ini);                    
+        [raw_D, fs_D, phs_D, weights_D, driftPreD, driftPostD]   = op_robustSpecReg(raw_D, 'HERMES', 0, refShift_ind_ini);     
     end
         
     
@@ -137,19 +178,28 @@ for kk = 1:MRSCont.nDatasets
     % actually have negative polarity, but end up positive in the data, so
     % that the spectrum needs to be flipped.
     raw_A_Cr    = op_freqrange(raw_A,2.8,3.2);
-    % Determine the polarity of the respective peak: if the absolute of the
-    % maximum minus the absolute of the minimum is positive, the polarity 
-    % of the respective peak is positive; if the absolute of the maximum 
-    % minus the absolute of the minimum is negative, the polarity is negative.
     polResidCr  = abs(max(real(raw_A_Cr.specs))) - abs(min(real(raw_A_Cr.specs)));
     if polResidCr < 0
         raw_A = op_ampScale(raw_A,-1);
+    end
+    
+    raw_B_Cr    = op_freqrange(raw_B,2.8,3.2);
+    polResidCr  = abs(max(real(raw_B_Cr.specs))) - abs(min(real(raw_B_Cr.specs)));
+    if polResidCr < 0
         raw_B = op_ampScale(raw_B,-1);
+    end
+    
+    raw_C_Cr    = op_freqrange(raw_C,2.8,3.2);
+    polResidCr  = abs(max(real(raw_C_Cr.specs))) - abs(min(real(raw_C_Cr.specs)));
+    if polResidCr < 0
         raw_C = op_ampScale(raw_C,-1);
+    end
+    
+    raw_D_Cr    = op_freqrange(raw_D,2.8,3.2);
+    polResidCr  = abs(max(real(raw_D_Cr.specs))) - abs(min(real(raw_D_Cr.specs)));
+    if polResidCr < 0
         raw_D = op_ampScale(raw_D,-1);
     end
-
-
     %%% 4. DETERMINE ON/OFF STATUS
     % Classify the four sub-spectra such that the OFF spectrum is stored to
     % field A, and the ON spectrum is stored to field B.
@@ -185,25 +235,40 @@ for kk = 1:MRSCont.nDatasets
     eval(['raw_B.specReg.phs    = phs_' subSpecNames{commuteOrder(2)} ';']);
     eval(['raw_C.specReg.phs    = phs_' subSpecNames{commuteOrder(3)} ';']);
     eval(['raw_D.specReg.phs    = phs_' subSpecNames{commuteOrder(4)} ';']);
-    eval(['raw_A.specReg.weights 	= weights_' subSpecNames{commuteOrder(1)} ';']);
-    eval(['raw_B.specReg.weights    = weights_' subSpecNames{commuteOrder(2)} ';']);
-    eval(['raw_C.specReg.weights    = weights_' subSpecNames{commuteOrder(3)} ';']);
-    eval(['raw_D.specReg.weights    = weights_' subSpecNames{commuteOrder(4)} ';']);
+    eval(['raw_A.specReg.weights 	= weights_' subSpecNames{commuteOrder(1)} '{1}(1,:);']);
+    eval(['raw_B.specReg.weights    = weights_' subSpecNames{commuteOrder(2)} '{1}(1,:);']);
+    eval(['raw_C.specReg.weights    = weights_' subSpecNames{commuteOrder(3)} '{1}(1,:);']);
+    eval(['raw_D.specReg.weights    = weights_' subSpecNames{commuteOrder(4)} '{1}(1,:);']);
+    raw_A.specReg.weights = raw_A.specReg.weights'/(max(raw_A.specReg.weights));
+    raw_B.specReg.weights = raw_B.specReg.weights'/(max(raw_B.specReg.weights));
+    raw_C.specReg.weights = raw_C.specReg.weights'/(max(raw_C.specReg.weights));
+    raw_D.specReg.weights = raw_D.specReg.weights'/(max(raw_D.specReg.weights));
     % Generate the frequency and phase plots for the entire experiment in
     % the correct order
     fs = [raw_A.specReg.fs, raw_B.specReg.fs, raw_C.specReg.fs, raw_D.specReg.fs]';
-    fs = reshape(fs, [raw.averages, 1]);
+    fs = reshape(fs, [raw.rawAverages, 1]);
     phs = [raw_A.specReg.phs, raw_B.specReg.phs, raw_C.specReg.phs, raw_D.specReg.phs]';
-    phs = reshape(phs, [raw.averages, 1]);
+    phs = reshape(phs, [raw.rawAverages, 1]);
+    weights = [raw_A.specReg.weights, raw_B.specReg.weights, raw_C.specReg.weights, raw_D.specReg.weights]';
+    weights = reshape(weights, [raw.rawAverages, 1]);
     MRSCont.raw{kk}.specReg.fs              = fs; % save align parameters
     MRSCont.raw{kk}.specReg.phs             = phs; % save align parameters
+    MRSCont.raw{kk}.specReg.weights             = weights; % save align parameters
 
     %%% 5. BUILD SUM AND DIFF SPECTRA %%%
     % Correct the frequency axis so that Cr appears at 3.027 ppm
-    [raw_A,~] = op_ppmref(raw_A, 2.9, 3.1, 3.027);
+    temp_spec   = op_addScans(raw_A,raw_B);
+    temp_spec   = op_addScans(temp_spec,raw_C);
+    temp_spec   = op_addScans(temp_spec,raw_D);    
+    [refShift_SubSpecAlign, ~] = osp_CrChoReferencing(temp_spec);
+    % Apply initial referencing shift
+    raw_A = op_freqshift(raw_A, -refShift_SubSpecAlign);
+    raw_B = op_freqshift(raw_B, -refShift_SubSpecAlign);
+    raw_C = op_freqshift(raw_C, -refShift_SubSpecAlign);
+    raw_D = op_freqshift(raw_D, -refShift_SubSpecAlign);
     % Fit a double-Lorentzian to the Cr-Cho area, and phase the spectrum
     % with the negative phase of that fit
-    [raw_A,~] = op_phaseCrCho(raw_A, 1);
+    [raw_A,~] = op_phaseCrCho(raw_A, 1); 
     % Align the sub-spectra to one another by minimizing the difference
     % between the common 'reporter' signals.
     [raw_A, raw_B, raw_C, raw_D] = osp_editSubSpecAlign(raw_A, raw_B, raw_C, raw_D);
@@ -212,20 +277,28 @@ for kk = 1:MRSCont.nDatasets
     sum     = op_addScans(sum,raw_C);
     sum     = op_addScans(sum,raw_D);
     sum.commuteOrder = commuteOrder;
+    sum.specReg.fs = fs;
+    sum.specReg.phs = phs;
+    sum.specReg.weights = weights;
     % Create the GABA-edited difference spectrum
     diff1   = op_addScans(raw_B,raw_D);
     diff1   = op_addScans(diff1,raw_A,1);
     diff1   = op_addScans(diff1,raw_C,1);
     diff1.target = target1;
     diff1.commuteOrder = commuteOrder;
+    diff1.specReg.fs = fs;
+    diff1.specReg.phs = phs;
+    diff1.specReg.weights = weights;
     % Create the GSH-edited difference spectrum
     diff2   = op_addScans(raw_C,raw_D);
     diff2   = op_addScans(diff2,raw_A,1);
     diff2   = op_addScans(diff2,raw_B,1);
     diff2.target = target2;
     diff2.commuteOrder = commuteOrder;
-    
-    
+    diff2.specReg.fs = fs;
+    diff2.specReg.phs = phs;
+    diff2.specReg.weights = weights;
+        
     %%% 6. REMOVE RESIDUAL WATER %%%
     % Remove water and correct back to baseline.
     % The spectra sometimes become NaNs after filtering with too many
@@ -310,13 +383,16 @@ for kk = 1:MRSCont.nDatasets
     
     %%% 7. REFERENCE SPECTRUM CORRECTLY TO FREQUENCY AXIS 
     % Reference resulting data correctly and consistently
-    [raw_A, refShift]   = op_ppmref(raw_A,1.8,2.2,2.008);          % Reference OFF-OFF spectrum to NAA @ 2.008 ppm                                                                          
-    [raw_B]             = op_freqshift(raw_B,refShift);            % Apply same shift to ON-OFF
-    [raw_C]             = op_freqshift(raw_C,refShift);            % Apply same shift to OFF-ON
-    [raw_D]             = op_freqshift(raw_D,refShift);            % Apply same shift to ON-ON
-    [diff1]             = op_freqshift(diff1,refShift);            % Apply same shift to diff1
-    [diff2]             = op_freqshift(diff2,refShift);            % Apply same shift to diff2
-    [sum]               = op_freqshift(sum,refShift);              % Apply same shift to sum
+    %[raw_A, refShift]   = op_ppmref(raw_A,1.8,2.2,2.008);          % Reference OFF-OFF spectrum to NAA @ 2.008 ppm
+    temp_spec = sum;
+    [refShift_final, ~] = osp_CrChoReferencing(temp_spec);% Reference OFF-OFF spectrum to NAA @ 2.008 ppm
+    [raw_A]             = op_freqshift(raw_A,-refShift_final);            % Apply same shift to ON-OFF
+    [raw_B]             = op_freqshift(raw_B,-refShift_final);            % Apply same shift to ON-OFF
+    [raw_C]             = op_freqshift(raw_C,-refShift_final);            % Apply same shift to OFF-ON
+    [raw_D]             = op_freqshift(raw_D,-refShift_final);            % Apply same shift to ON-ON
+    [diff1]             = op_freqshift(diff1,-refShift_final);            % Apply same shift to diff1
+    [diff2]             = op_freqshift(diff2,-refShift_final);            % Apply same shift to diff2
+    [sum]               = op_freqshift(sum,-refShift_final);              % Apply same shift to sum
     
     % Add commuteOrder
     raw_A.commuteOrder = commuteOrder(1);
@@ -362,49 +438,49 @@ for kk = 1:MRSCont.nDatasets
     MRSCont.QM.SNR.A(kk)    = op_getSNR(MRSCont.processed.A{kk}); % NAA amplitude over noise floor
     FWHM_Hz                 = op_getLW(MRSCont.processed.A{kk},1.8,2.2); % in Hz
     MRSCont.QM.FWHM.A(kk)   = FWHM_Hz./MRSCont.processed.A{kk}.txfrq*1e6; % convert to ppm
-    MRSCont.QM.freqShift.A(kk)  = refShift;
+    MRSCont.QM.freqShift.A(kk)  = refShift_SubSpecAlign + refShift_final;
     MRSCont.QM.drift.pre.AvgDeltaCr.A(kk) = mean(MRSCont.QM.drift.pre.A{kk} - 3.02);
     MRSCont.QM.drift.post.AvgDeltaCr.A(kk) = mean(MRSCont.QM.drift.post.A{kk} - 3.02);
     
     MRSCont.QM.SNR.B(kk)    = op_getSNR(MRSCont.processed.B{kk},2.8,3.2); % Cr amplitude over noise floor
     FWHM_Hz                 = op_getLW(MRSCont.processed.B{kk},2.8,3.2); % in Hz
     MRSCont.QM.FWHM.B(kk)   = FWHM_Hz./MRSCont.processed.B{kk}.txfrq*1e6; % convert to ppm
-    MRSCont.QM.freqShift.B(kk)  = refShift;
+    MRSCont.QM.freqShift.B(kk)  = refShift_SubSpecAlign + refShift_final;
     MRSCont.QM.drift.pre.AvgDeltaCr.B(kk) = mean(MRSCont.QM.drift.pre.B{kk} - 3.02);
     MRSCont.QM.drift.post.AvgDeltaCr.B(kk) = mean(MRSCont.QM.drift.post.B{kk} - 3.02);
     
     MRSCont.QM.SNR.C(kk)    = op_getSNR(MRSCont.processed.C{kk}); % NAA amplitude over noise floor
     FWHM_Hz                 = op_getLW(MRSCont.processed.C{kk},1.8,2.2); % in Hz
     MRSCont.QM.FWHM.C(kk)   = FWHM_Hz./MRSCont.processed.C{kk}.txfrq*1e6; % convert to ppm
-    MRSCont.QM.freqShift.C(kk)  = refShift;
+    MRSCont.QM.freqShift.C(kk)  = refShift_SubSpecAlign + refShift_final;
     MRSCont.QM.drift.pre.AvgDeltaCr.C(kk) = mean(MRSCont.QM.drift.pre.C{kk} - 3.02);
     MRSCont.QM.drift.post.AvgDeltaCr.C(kk) = mean(MRSCont.QM.drift.post.C{kk} - 3.02);
     
     MRSCont.QM.SNR.D(kk)    = op_getSNR(MRSCont.processed.D{kk},2.8,3.2); % Cr amplitude over noise floor
     FWHM_Hz                 = op_getLW(MRSCont.processed.D{kk},2.8,3.2); % in Hz
     MRSCont.QM.FWHM.D(kk)   = FWHM_Hz./MRSCont.processed.D{kk}.txfrq*1e6; % convert to ppm
-    MRSCont.QM.freqShift.D(kk)  = refShift;
+    MRSCont.QM.freqShift.D(kk)  = refShift_SubSpecAlign + refShift_final;
     MRSCont.QM.drift.pre.AvgDeltaCr.D(kk) = mean(MRSCont.QM.drift.pre.D{kk} - 3.02);
     MRSCont.QM.drift.post.AvgDeltaCr.D(kk) = mean(MRSCont.QM.drift.post.D{kk} - 3.02);
     
     MRSCont.QM.SNR.diff1(kk)    = op_getSNR(MRSCont.processed.diff1{kk},2.8,3.2); % GABA amplitude over noise floor
     FWHM_Hz                 = op_getLW(MRSCont.processed.diff1{kk},2.8,3.2); % in Hz
     MRSCont.QM.FWHM.diff1(kk)   = FWHM_Hz./MRSCont.processed.diff1{kk}.txfrq*1e6; % convert to ppm
-    MRSCont.QM.freqShift.diff1(kk)  = refShift;
+    MRSCont.QM.freqShift.diff1(kk)  = refShift_SubSpecAlign + refShift_final;
     MRSCont.QM.drift.pre.AvgDeltaCr.diff1(kk) = mean(MRSCont.QM.drift.pre.diff1{kk} - 3.02);
     MRSCont.QM.drift.post.AvgDeltaCr.diff1(kk) = mean(MRSCont.QM.drift.post.diff1{kk} - 3.02);
     
     MRSCont.QM.SNR.diff2(kk)    = op_getSNR(MRSCont.processed.diff2{kk},2.8,3.2); % GSH amplitude over noise floor
     FWHM_Hz                 = op_getLW(MRSCont.processed.diff2{kk},2.8,3.2); % in Hz
     MRSCont.QM.FWHM.diff2(kk)   = FWHM_Hz./MRSCont.processed.diff1{kk}.txfrq*1e6; % convert to ppm
-    MRSCont.QM.freqShift.diff2(kk)  = refShift;
+    MRSCont.QM.freqShift.diff2(kk)  = refShift_SubSpecAlign + refShift_final;
     MRSCont.QM.drift.pre.AvgDeltaCr.diff2(kk) = mean(MRSCont.QM.drift.pre.diff2{kk} - 3.02);
     MRSCont.QM.drift.post.AvgDeltaCr.diff2(kk) = mean(MRSCont.QM.drift.post.diff2{kk} - 3.02);
     
     MRSCont.QM.SNR.sum(kk)    = op_getSNR(MRSCont.processed.sum{kk}); % Cr amplitude over noise floor
     FWHM_Hz                     = op_getLW(MRSCont.processed.sum{kk},2.8,3.2); % in Hz
     MRSCont.QM.FWHM.sum(kk)   = FWHM_Hz./MRSCont.processed.sum{kk}.txfrq*1e6; % convert to ppm
-    MRSCont.QM.freqShift.sum(kk)  = refShift;
+    MRSCont.QM.freqShift.sum(kk)  = refShift_SubSpecAlign + refShift_final;
     MRSCont.QM.drift.pre.AvgDeltaCr.sum(kk) = mean(MRSCont.QM.drift.pre.sum{kk} - 3.02);
     MRSCont.QM.drift.post.AvgDeltaCr.sum(kk) = mean(MRSCont.QM.drift.post.sum{kk} - 3.02);
     

--- a/process/osp_processHERMES.m
+++ b/process/osp_processHERMES.m
@@ -59,39 +59,80 @@ for kk = 1:MRSCont.nDatasets
         raw_C   = op_takesubspec(raw,3);                    % Get third subspectrum
         raw_D   = op_takesubspec(raw,4);                    % Get fourth subspectrum
         
-        % Measure and save drift information
-        driftPreA    = op_measureDrift(raw_A);
-        driftPreB    = op_measureDrift(raw_B);
-        driftPreC    = op_measureDrift(raw_C);
-        driftPreD    = op_measureDrift(raw_D);
-        MRSCont.QM.drift.pre.diff1{kk}  = [driftPreA driftPreB driftPreC driftPreD];
-        MRSCont.QM.drift.pre.diff2{kk}  = [driftPreA driftPreB driftPreC driftPreD];
-        MRSCont.QM.drift.pre.sum{kk}    = [driftPreA driftPreB driftPreC driftPreD];
-        
     else
-        % Measure and save drift information
-        driftPre    = op_measureDrift(raw);
-        MRSCont.QM.drift.pre.diff1{kk}  = driftPre;
-        MRSCont.QM.drift.pre.diff2{kk}  = driftPre;
-        MRSCont.QM.drift.pre.sum{kk}    = driftPre;
-    
+
         raw_A   = op_takeaverages(raw,1:4:raw.averages);    % Get first subspectrum
         raw_B   = op_takeaverages(raw,2:4:raw.averages);    % Get second subspectrum
         raw_C   = op_takeaverages(raw,3:4:raw.averages);    % Get third subspectrum
         raw_D   = op_takeaverages(raw,4:4:raw.averages);    % Get fourth subspectrum
     end
     
+
+    temp_A = op_averaging(raw_A);
+    raw_A_Cr    = op_freqrange(temp_A,2.8,3.2);
+    % Determine the polarity of the respective peak: if the absolute of the
+    % maximum minus the absolute of the minimum is positive, the polarity 
+    % of the respective peak is positive; if the absolute of the maximum 
+    % minus the absolute of the minimum is negative, the polarity is negative.
+    polResidCr  = abs(max(real(raw_A_Cr.specs))) - abs(min(real(raw_A_Cr.specs)));
+    temp_rawA = raw_A;
+    if polResidCr < 0        
+        temp_rawA = op_ampScale(temp_rawA,-1);
+    end
+    
+    temp_B = op_averaging(raw_B);
+    raw_B_Cr    = op_freqrange(temp_B,2.8,3.2);
+    polResidCr  = abs(max(real(raw_B_Cr.specs))) - abs(min(real(raw_B_Cr.specs)));
+    temp_rawB = raw_B;
+    if polResidCr < 0        
+        temp_rawB = op_ampScale(temp_rawB,-1);
+    end
+    
+    temp_C = op_averaging(raw_C);
+    raw_C_Cr    = op_freqrange(temp_C,2.8,3.2);
+    polResidCr  = abs(max(real(raw_C_Cr.specs))) - abs(min(real(raw_C_Cr.specs)));
+    temp_rawC = raw_C;
+    if polResidCr < 0        
+        temp_rawC = op_ampScale(temp_rawC,-1);
+    end
+    
+    temp_D = op_averaging(raw_D);
+    raw_D_Cr    = op_freqrange(temp_D,2.8,3.2);
+    polResidCr  = abs(max(real(raw_D_Cr.specs))) - abs(min(real(raw_D_Cr.specs)));
+    temp_rawD = raw_D;
+    if polResidCr < 0        
+        temp_rawD = op_ampScale(temp_rawD,-1);
+    end
+    temp_proc   = op_addScans(temp_rawA,temp_rawB);
+    temp_proc   = op_addScans(temp_proc,temp_rawC);
+    temp_proc   = op_addScans(temp_proc,temp_rawD);
+    temp_spec   = temp_proc;
+    for av = 1 : round(temp_rawA.averages*0.1) :temp_rawA.averages-(round(temp_rawA.averages*0.1)-1)-mod(temp_rawA.averages,round(temp_rawA.averages*0.1))
+        fids = temp_proc.fids(:,av:av+(round(temp_rawA.averages*0.1)-1));
+        specs = temp_proc.specs(:,av:av+(round(temp_rawA.averages*0.1)-1));
+        temp_spec.fids = mean(fids,2);
+        temp_spec.specs = mean(specs,2);
+        [refShift, ~] = osp_CrChoReferencing(temp_spec);
+        refShift_ind_ini(av : av+round(temp_rawA.averages*0.1)-1) = refShift;
+    end
+    if mod(temp_rawA.averages,round(temp_rawA.averages*0.1)) > 0
+        fids = temp_proc.fids(:,end-(mod(temp_rawA.averages,round(temp_rawA.averages*0.1))-1):end);
+        specs = temp_proc.specs(:,end-(mod(temp_rawA.averages,round(temp_rawA.averages*0.1))-1):end);
+        temp_spec.fids = mean(fids,2);
+        temp_spec.specs = mean(specs,2);
+        [refShift, ~] = osp_CrChoReferencing(temp_spec);
+        refShift_ind_ini(end-(mod(temp_rawA.averages,round(temp_rawA.averages*0.1))-1) : temp_rawA.averages) = refShift;        
+    end
+    
     % Perform robust spectral correction with weighted averaging.
     % This can obviously only be done, if the spectra have not been 
     % pre-averaged, i.e. in some older RDA and DICOM files (which should, 
     % generally, not be used).
-    if ~raw.flags.averaged
-        
-        [raw_A, fs_A, phs_A, weights_A, driftPreA, driftPostA]   = op_robustSpecReg(raw_A, 'HERMES', 0);
-        [raw_B, fs_B, phs_B, weights_B, driftPreB, driftPostB]   = op_robustSpecReg(raw_B, 'HERMES', 0);                  
-        [raw_C, fs_C, phs_C, weights_C, driftPreC, driftPostC]   = op_robustSpecReg(raw_C, 'HERMES', 0);                    
-        [raw_D, fs_D, phs_D, weights_D, driftPreD, driftPostD]   = op_robustSpecReg(raw_D, 'HERMES', 0);     
-
+    if ~raw.flags.averaged       
+        [raw_A, fs_A, phs_A, weights_A, driftPreA, driftPostA]   = op_robustSpecReg(raw_A, 'HERMES', 0,refShift_ind_ini);
+        [raw_B, fs_B, phs_B, weights_B, driftPreB, driftPostB]   = op_robustSpecReg(raw_B, 'HERMES', 0, refShift_ind_ini);                  
+        [raw_C, fs_C, phs_C, weights_C, driftPreC, driftPostC]   = op_robustSpecReg(raw_C, 'HERMES', 0, refShift_ind_ini);                    
+        [raw_D, fs_D, phs_D, weights_D, driftPreD, driftPostD]   = op_robustSpecReg(raw_D, 'HERMES', 0, refShift_ind_ini);     
     end
         
     
@@ -137,19 +178,28 @@ for kk = 1:MRSCont.nDatasets
     % actually have negative polarity, but end up positive in the data, so
     % that the spectrum needs to be flipped.
     raw_A_Cr    = op_freqrange(raw_A,2.8,3.2);
-    % Determine the polarity of the respective peak: if the absolute of the
-    % maximum minus the absolute of the minimum is positive, the polarity 
-    % of the respective peak is positive; if the absolute of the maximum 
-    % minus the absolute of the minimum is negative, the polarity is negative.
     polResidCr  = abs(max(real(raw_A_Cr.specs))) - abs(min(real(raw_A_Cr.specs)));
     if polResidCr < 0
         raw_A = op_ampScale(raw_A,-1);
+    end
+    
+    raw_B_Cr    = op_freqrange(raw_B,2.8,3.2);
+    polResidCr  = abs(max(real(raw_B_Cr.specs))) - abs(min(real(raw_B_Cr.specs)));
+    if polResidCr < 0
         raw_B = op_ampScale(raw_B,-1);
+    end
+    
+    raw_C_Cr    = op_freqrange(raw_C,2.8,3.2);
+    polResidCr  = abs(max(real(raw_C_Cr.specs))) - abs(min(real(raw_C_Cr.specs)));
+    if polResidCr < 0
         raw_C = op_ampScale(raw_C,-1);
+    end
+    
+    raw_D_Cr    = op_freqrange(raw_D,2.8,3.2);
+    polResidCr  = abs(max(real(raw_D_Cr.specs))) - abs(min(real(raw_D_Cr.specs)));
+    if polResidCr < 0
         raw_D = op_ampScale(raw_D,-1);
     end
-
-
     %%% 4. DETERMINE ON/OFF STATUS
     % Classify the four sub-spectra such that the OFF spectrum is stored to
     % field A, and the ON spectrum is stored to field B.
@@ -185,25 +235,40 @@ for kk = 1:MRSCont.nDatasets
     eval(['raw_B.specReg.phs    = phs_' subSpecNames{commuteOrder(2)} ';']);
     eval(['raw_C.specReg.phs    = phs_' subSpecNames{commuteOrder(3)} ';']);
     eval(['raw_D.specReg.phs    = phs_' subSpecNames{commuteOrder(4)} ';']);
-    eval(['raw_A.specReg.weights 	= weights_' subSpecNames{commuteOrder(1)} ';']);
-    eval(['raw_B.specReg.weights    = weights_' subSpecNames{commuteOrder(2)} ';']);
-    eval(['raw_C.specReg.weights    = weights_' subSpecNames{commuteOrder(3)} ';']);
-    eval(['raw_D.specReg.weights    = weights_' subSpecNames{commuteOrder(4)} ';']);
+    eval(['raw_A.specReg.weights 	= weights_' subSpecNames{commuteOrder(1)} '{1}(1,:);']);
+    eval(['raw_B.specReg.weights    = weights_' subSpecNames{commuteOrder(2)} '{1}(1,:);']);
+    eval(['raw_C.specReg.weights    = weights_' subSpecNames{commuteOrder(3)} '{1}(1,:);']);
+    eval(['raw_D.specReg.weights    = weights_' subSpecNames{commuteOrder(4)} '{1}(1,:);']);
+    raw_A.specReg.weights = raw_A.specReg.weights'/(max(raw_A.specReg.weights));
+    raw_B.specReg.weights = raw_B.specReg.weights'/(max(raw_B.specReg.weights));
+    raw_C.specReg.weights = raw_C.specReg.weights'/(max(raw_C.specReg.weights));
+    raw_D.specReg.weights = raw_D.specReg.weights'/(max(raw_D.specReg.weights));
     % Generate the frequency and phase plots for the entire experiment in
     % the correct order
     fs = [raw_A.specReg.fs, raw_B.specReg.fs, raw_C.specReg.fs, raw_D.specReg.fs]';
-    fs = reshape(fs, [raw.averages, 1]);
+    fs = reshape(fs, [raw.rawAverages, 1]);
     phs = [raw_A.specReg.phs, raw_B.specReg.phs, raw_C.specReg.phs, raw_D.specReg.phs]';
-    phs = reshape(phs, [raw.averages, 1]);
+    phs = reshape(phs, [raw.rawAverages, 1]);
+    weights = [raw_A.specReg.weights, raw_B.specReg.weights, raw_C.specReg.weights, raw_D.specReg.weights]';
+    weights = reshape(weights, [raw.rawAverages, 1]);
     MRSCont.raw{kk}.specReg.fs              = fs; % save align parameters
     MRSCont.raw{kk}.specReg.phs             = phs; % save align parameters
+    MRSCont.raw{kk}.specReg.weights             = weights; % save align parameters
 
     %%% 5. BUILD SUM AND DIFF SPECTRA %%%
     % Correct the frequency axis so that Cr appears at 3.027 ppm
-    [raw_A,~] = op_ppmref(raw_A, 2.9, 3.1, 3.027);
+    temp_spec   = op_addScans(raw_A,raw_B);
+    temp_spec   = op_addScans(temp_spec,raw_C);
+    temp_spec   = op_addScans(temp_spec,raw_D);    
+    [refShift_SubSpecAlign, ~] = osp_CrChoReferencing(temp_spec);
+    % Apply initial referencing shift
+    raw_A = op_freqshift(raw_A, -refShift_SubSpecAlign);
+    raw_B = op_freqshift(raw_B, -refShift_SubSpecAlign);
+    raw_C = op_freqshift(raw_C, -refShift_SubSpecAlign);
+    raw_D = op_freqshift(raw_D, -refShift_SubSpecAlign);
     % Fit a double-Lorentzian to the Cr-Cho area, and phase the spectrum
     % with the negative phase of that fit
-    [raw_A,~] = op_phaseCrCho(raw_A, 1);
+    [raw_A,~] = op_phaseCrCho(raw_A, 1); 
     % Align the sub-spectra to one another by minimizing the difference
     % between the common 'reporter' signals.
     [raw_A, raw_B, raw_C, raw_D] = osp_editSubSpecAlign(raw_A, raw_B, raw_C, raw_D);
@@ -212,20 +277,28 @@ for kk = 1:MRSCont.nDatasets
     sum     = op_addScans(sum,raw_C);
     sum     = op_addScans(sum,raw_D);
     sum.commuteOrder = commuteOrder;
+    sum.specReg.fs = fs;
+    sum.specReg.phs = phs;
+    sum.specReg.weights = weights;
     % Create the GABA-edited difference spectrum
     diff1   = op_addScans(raw_B,raw_D);
     diff1   = op_addScans(diff1,raw_A,1);
     diff1   = op_addScans(diff1,raw_C,1);
     diff1.target = target1;
     diff1.commuteOrder = commuteOrder;
+    diff1.specReg.fs = fs;
+    diff1.specReg.phs = phs;
+    diff1.specReg.weights = weights;
     % Create the GSH-edited difference spectrum
     diff2   = op_addScans(raw_C,raw_D);
     diff2   = op_addScans(diff2,raw_A,1);
     diff2   = op_addScans(diff2,raw_B,1);
     diff2.target = target2;
     diff2.commuteOrder = commuteOrder;
-    
-    
+    diff2.specReg.fs = fs;
+    diff2.specReg.phs = phs;
+    diff2.specReg.weights = weights;
+        
     %%% 6. REMOVE RESIDUAL WATER %%%
     % Remove water and correct back to baseline.
     % The spectra sometimes become NaNs after filtering with too many
@@ -310,13 +383,16 @@ for kk = 1:MRSCont.nDatasets
     
     %%% 7. REFERENCE SPECTRUM CORRECTLY TO FREQUENCY AXIS 
     % Reference resulting data correctly and consistently
-    [raw_A, refShift]   = op_ppmref(raw_A,1.8,2.2,2.008);          % Reference OFF-OFF spectrum to NAA @ 2.008 ppm                                                                          
-    [raw_B]             = op_freqshift(raw_B,refShift);            % Apply same shift to ON-OFF
-    [raw_C]             = op_freqshift(raw_C,refShift);            % Apply same shift to OFF-ON
-    [raw_D]             = op_freqshift(raw_D,refShift);            % Apply same shift to ON-ON
-    [diff1]             = op_freqshift(diff1,refShift);            % Apply same shift to diff1
-    [diff2]             = op_freqshift(diff2,refShift);            % Apply same shift to diff2
-    [sum]               = op_freqshift(sum,refShift);              % Apply same shift to sum
+    %[raw_A, refShift]   = op_ppmref(raw_A,1.8,2.2,2.008);          % Reference OFF-OFF spectrum to NAA @ 2.008 ppm
+    temp_spec = sum;
+    [refShift_final, ~] = osp_CrChoReferencing(temp_spec);% Reference OFF-OFF spectrum to NAA @ 2.008 ppm
+    [raw_A]             = op_freqshift(raw_A,-refShift_final);            % Apply same shift to ON-OFF
+    [raw_B]             = op_freqshift(raw_B,-refShift_final);            % Apply same shift to ON-OFF
+    [raw_C]             = op_freqshift(raw_C,-refShift_final);            % Apply same shift to OFF-ON
+    [raw_D]             = op_freqshift(raw_D,-refShift_final);            % Apply same shift to ON-ON
+    [diff1]             = op_freqshift(diff1,-refShift_final);            % Apply same shift to diff1
+    [diff2]             = op_freqshift(diff2,-refShift_final);            % Apply same shift to diff2
+    [sum]               = op_freqshift(sum,-refShift_final);              % Apply same shift to sum
     
     % Add commuteOrder
     raw_A.commuteOrder = commuteOrder(1);
@@ -362,49 +438,49 @@ for kk = 1:MRSCont.nDatasets
     MRSCont.QM.SNR.A(kk)    = op_getSNR(MRSCont.processed.A{kk}); % NAA amplitude over noise floor
     FWHM_Hz                 = op_getLW(MRSCont.processed.A{kk},1.8,2.2); % in Hz
     MRSCont.QM.FWHM.A(kk)   = FWHM_Hz./MRSCont.processed.A{kk}.txfrq*1e6; % convert to ppm
-    MRSCont.QM.freqShift.A(kk)  = refShift;
+    MRSCont.QM.freqShift.A(kk)  = refShift_SubSpecAlign + refShift_final;
     MRSCont.QM.drift.pre.AvgDeltaCr.A(kk) = mean(MRSCont.QM.drift.pre.A{kk} - 3.02);
     MRSCont.QM.drift.post.AvgDeltaCr.A(kk) = mean(MRSCont.QM.drift.post.A{kk} - 3.02);
     
     MRSCont.QM.SNR.B(kk)    = op_getSNR(MRSCont.processed.B{kk},2.8,3.2); % Cr amplitude over noise floor
     FWHM_Hz                 = op_getLW(MRSCont.processed.B{kk},2.8,3.2); % in Hz
     MRSCont.QM.FWHM.B(kk)   = FWHM_Hz./MRSCont.processed.B{kk}.txfrq*1e6; % convert to ppm
-    MRSCont.QM.freqShift.B(kk)  = refShift;
+    MRSCont.QM.freqShift.B(kk)  = refShift_SubSpecAlign + refShift_final;
     MRSCont.QM.drift.pre.AvgDeltaCr.B(kk) = mean(MRSCont.QM.drift.pre.B{kk} - 3.02);
     MRSCont.QM.drift.post.AvgDeltaCr.B(kk) = mean(MRSCont.QM.drift.post.B{kk} - 3.02);
     
     MRSCont.QM.SNR.C(kk)    = op_getSNR(MRSCont.processed.C{kk}); % NAA amplitude over noise floor
     FWHM_Hz                 = op_getLW(MRSCont.processed.C{kk},1.8,2.2); % in Hz
     MRSCont.QM.FWHM.C(kk)   = FWHM_Hz./MRSCont.processed.C{kk}.txfrq*1e6; % convert to ppm
-    MRSCont.QM.freqShift.C(kk)  = refShift;
+    MRSCont.QM.freqShift.C(kk)  = refShift_SubSpecAlign + refShift_final;
     MRSCont.QM.drift.pre.AvgDeltaCr.C(kk) = mean(MRSCont.QM.drift.pre.C{kk} - 3.02);
     MRSCont.QM.drift.post.AvgDeltaCr.C(kk) = mean(MRSCont.QM.drift.post.C{kk} - 3.02);
     
     MRSCont.QM.SNR.D(kk)    = op_getSNR(MRSCont.processed.D{kk},2.8,3.2); % Cr amplitude over noise floor
     FWHM_Hz                 = op_getLW(MRSCont.processed.D{kk},2.8,3.2); % in Hz
     MRSCont.QM.FWHM.D(kk)   = FWHM_Hz./MRSCont.processed.D{kk}.txfrq*1e6; % convert to ppm
-    MRSCont.QM.freqShift.D(kk)  = refShift;
+    MRSCont.QM.freqShift.D(kk)  = refShift_SubSpecAlign + refShift_final;
     MRSCont.QM.drift.pre.AvgDeltaCr.D(kk) = mean(MRSCont.QM.drift.pre.D{kk} - 3.02);
     MRSCont.QM.drift.post.AvgDeltaCr.D(kk) = mean(MRSCont.QM.drift.post.D{kk} - 3.02);
     
     MRSCont.QM.SNR.diff1(kk)    = op_getSNR(MRSCont.processed.diff1{kk},2.8,3.2); % GABA amplitude over noise floor
     FWHM_Hz                 = op_getLW(MRSCont.processed.diff1{kk},2.8,3.2); % in Hz
     MRSCont.QM.FWHM.diff1(kk)   = FWHM_Hz./MRSCont.processed.diff1{kk}.txfrq*1e6; % convert to ppm
-    MRSCont.QM.freqShift.diff1(kk)  = refShift;
+    MRSCont.QM.freqShift.diff1(kk)  = refShift_SubSpecAlign + refShift_final;
     MRSCont.QM.drift.pre.AvgDeltaCr.diff1(kk) = mean(MRSCont.QM.drift.pre.diff1{kk} - 3.02);
     MRSCont.QM.drift.post.AvgDeltaCr.diff1(kk) = mean(MRSCont.QM.drift.post.diff1{kk} - 3.02);
     
     MRSCont.QM.SNR.diff2(kk)    = op_getSNR(MRSCont.processed.diff2{kk},2.8,3.2); % GSH amplitude over noise floor
     FWHM_Hz                 = op_getLW(MRSCont.processed.diff2{kk},2.8,3.2); % in Hz
     MRSCont.QM.FWHM.diff2(kk)   = FWHM_Hz./MRSCont.processed.diff1{kk}.txfrq*1e6; % convert to ppm
-    MRSCont.QM.freqShift.diff2(kk)  = refShift;
+    MRSCont.QM.freqShift.diff2(kk)  = refShift_SubSpecAlign + refShift_final;
     MRSCont.QM.drift.pre.AvgDeltaCr.diff2(kk) = mean(MRSCont.QM.drift.pre.diff2{kk} - 3.02);
     MRSCont.QM.drift.post.AvgDeltaCr.diff2(kk) = mean(MRSCont.QM.drift.post.diff2{kk} - 3.02);
     
     MRSCont.QM.SNR.sum(kk)    = op_getSNR(MRSCont.processed.sum{kk}); % Cr amplitude over noise floor
     FWHM_Hz                     = op_getLW(MRSCont.processed.sum{kk},2.8,3.2); % in Hz
     MRSCont.QM.FWHM.sum(kk)   = FWHM_Hz./MRSCont.processed.sum{kk}.txfrq*1e6; % convert to ppm
-    MRSCont.QM.freqShift.sum(kk)  = refShift;
+    MRSCont.QM.freqShift.sum(kk)  = refShift_SubSpecAlign + refShift_final;
     MRSCont.QM.drift.pre.AvgDeltaCr.sum(kk) = mean(MRSCont.QM.drift.pre.sum{kk} - 3.02);
     MRSCont.QM.drift.post.AvgDeltaCr.sum(kk) = mean(MRSCont.QM.drift.post.sum{kk} - 3.02);
     

--- a/seg/OspreySeg.m
+++ b/seg/OspreySeg.m
@@ -156,8 +156,9 @@ fprintf('... done.\n');
 toc(refProcessTime);
 
 %% Clean up and save
-% Set exit flags
+% Set exit flags and version
 MRSCont.flags.didSeg           = 1;
+MRSCont.ver.Seg             = '100 Seg';
 
 % Save the output structure to the output folder
 % Determine output folder


### PR DESCRIPTION
Updated all processing piplines including new referencing based on crosscorrealtion prior to spec reg, subspec alignemnt and as final referencing step.
Changed both crosscorrelleation referencing functions to operate between 4.2 and 1.85  ppm, as residual water and fat contamination could lead to misalignment. Additionally, this makes whitaker filtering prior to this step unnacesary, which sometimes screws up the creatine and choline peaks.