### PR TITLE
Robuster-SpecReg

### DIFF
--- a/fit/osp_fitHERMES.m
+++ b/fit/osp_fitHERMES.m
@@ -68,6 +68,8 @@ for kk = 1:MRSCont.nDatasets
         basisSetDiff1.fids = basisSetDiff1.fids(:,:,5);
         basisSetDiff1.specs = basisSetDiff1.specs(:,:,5);
         dataToFit   = op_ampScale(dataToFit, 1/MRSCont.fit.scale{kk});
+        dataToFit.refShift   = fitParamsSum.refShift;
+        dataToFit.refFWHM   = fitParamsSum.refFWHM;
 
         % Call the fit function
         [fitParamsDiff1, resBasisSetDiff1]  = fit_runFit(dataToFit, basisSetDiff1, fitModel, fitOpts);

--- a/libraries/FID-A/processingTools/op_freqshift.m
+++ b/libraries/FID-A/processingTools/op_freqshift.m
@@ -27,13 +27,21 @@ function out=op_freqshift(in,f);
 %     error('ERROR:  Can not operate on data with multiple Subspecs!  ABORTING!!');
 % end
 
-t=repmat(in.t',[1 in.sz(2:end)]);
 
-fids=in.fids.*exp(-1i*t*f*2*pi);
+if length(f) > 1
+    t=repmat(in.t',[1 in.sz(2:end)]);
+    t = t(:,1);
+    fids = in.fids;
+    for av = 1 : in.averages
+        fids(:,av)=in.fids(:,av).*exp(-1i*t*f(av)*2*pi);
+    end
+else
+    t=repmat(in.t',[1 in.sz(2:end)]);
+    fids=in.fids.*exp(-1i*t*f*2*pi);
+end
 
 %re-calculate Specs using fft
 specs=fftshift(fft(fids,[],in.dims.t),in.dims.t);
-
 %plot(in1.ppm,combinedSpecs);
 
 %FILLING IN DATA STRUCTURES


### PR DESCRIPTION
Added inital guess for the frequncy shifts to robust spec reg, which is based on a sliding average (10% of the transients) window followed by referencing based on crosscorrelation of Cr and Cho.