### PR TITLE
Hotfix version number

### DIFF
--- a/job/OspreyJob.m
+++ b/job/OspreyJob.m
@@ -378,7 +378,7 @@ MRSCont.flags.isGUI     = GUI;
 %%% 7. SET FLAGS AND VERSION %%%
 MRSCont.flags.didLoadJob    = 1;
 MRSCont.loadedJob           = jobFile;
-MRSCont.ver.Osp             = 'Osprey 1.0.0';
+MRSCont.ver.Osp             = 'Osprey 1.0.1';
 
 
 %%% 8. CHECK IF OUTPUT STRUCTURE ALREADY EXISTS IN OUTPUT FOLDER %%%


### PR DESCRIPTION
-Fixes version comparison for v1.0.1 . The integrated version comparison was not properly update, therefore the GUI did not show the content of an already processed MRS container.