### PR TITLE
MRSI_data_list_update

### DIFF
--- a/load/mrsi/load_mrsi_data.m
+++ b/load/mrsi/load_mrsi_data.m
@@ -169,8 +169,10 @@ for kk = 1:MRSCont.nDatasets
             all_count(dl) = count;
             loc(dl) = this_dl(5) + 1;
             coil(dl) = this_dl(6);
-            kx(dl) = this_dl(9);
-            ky(dl) = this_dl(10);
+%             kx(dl) = this_dl(9);
+%             ky(dl) = this_dl(10);
+            kx(dl) = this_dl(10);
+            ky(dl) = this_dl(9);
             avg(dl) = this_dl(12);
             sign(dl) = this_dl(13);
         end

--- a/load/mrsi/process_wat_ref.m
+++ b/load/mrsi/process_wat_ref.m
@@ -44,8 +44,10 @@ for dl = 1:(length(data_lines))
     end
     loc(dl) = this_dl(5) + 1;
     coil(dl) = this_dl(6);
-    kx(dl) = this_dl(9);
-    ky(dl) = this_dl(10);
+%     kx(dl) = this_dl(9);
+%     ky(dl) = this_dl(10);
+    kx(dl) = this_dl(10);
+    ky(dl) = this_dl(9);
     avg(dl) = this_dl(12);
     sign(dl) = this_dl(13);
 end


### PR DESCRIPTION
-Apparently the index of the number kx and ky lines have changed in R 5.7.1. This still needs some further testing.