### PR TITLE
Added 7T relaxation time lookup table

### DIFF
--- a/quantify/OspreyQuantify.m
+++ b/quantify/OspreyQuantify.m
@@ -95,6 +95,15 @@ elseif [MRSCont.flags.hasRef MRSCont.flags.hasWater] == [0 0]
         qtfyH2O     = 0;
 end
 
+% Get the fieldstrength for proper relaxation correction
+if qtfyH2O
+    Bo = MRSCont.raw{1}.Bo;  
+    if (Bo >= 2.8 && Bo < 3.1)
+            Bo = '3T';
+    else
+            Bo = '7T';
+    end
+end
 % Check whether segmentation has been run, and whether tissue parameters
 % exist. In that case, we can do CSF correction, and full tissue
 % correction.
@@ -201,7 +210,7 @@ for kk = 1:MRSCont.nDatasets
         metsTE  = MRSCont.processed.A{kk}.te * 1e-3;
         waterTE = MRSCont.processed.(waterType){kk}.te * 1e-3;
         % Calculate water-scaled, but not tissue-corrected metabolite levels
-        rawWaterScaled = quantH2O(metsName, amplMets, amplWater, getResults, metsTR, waterTR, metsTE, waterTE);
+        rawWaterScaled = quantH2O(metsName, amplMets, amplWater, getResults, metsTR, waterTR, metsTE, waterTE,Bo);
 
         % Save back to Osprey data container
         for ll = 1:length(getResults)
@@ -231,7 +240,7 @@ for kk = 1:MRSCont.nDatasets
         % Apply tissue correction
         fGM = MRSCont.seg.tissue.fGM(kk,:);
         fWM = MRSCont.seg.tissue.fWM(kk,:);
-        TissCorrWaterScaled = quantTiss(metsName, amplMets, amplWater, getResults, metsTR, waterTR, metsTE, waterTE, fGM, fWM, fCSF);
+        TissCorrWaterScaled = quantTiss(metsName, amplMets, amplWater, getResults, metsTR, waterTR, metsTE, waterTE, fGM, fWM, fCSF,Bo);
 
         % Save back to Osprey data container
         for ll = 1:length(getResults)        
@@ -250,7 +259,7 @@ for kk = 1:MRSCont.nDatasets
         % Calculate mean WM/GM fractions
         meanfGM = mean(MRSCont.seg.tissue.fGM,1); % average GM fraction across datasets
         meanfWM = mean(MRSCont.seg.tissue.fWM,1); % average WM fraction across datasets
-        [AlphaCorrWaterScaled, AlphaCorrWaterScaledGroupNormed] = quantAlpha(metsName,amplMets, amplWater,getResults, metsTR, waterTR, metsTE, waterTE, fGM, fWM, fCSF, meanfGM, meanfWM,MRSCont.opts.fit.coMM3);
+        [AlphaCorrWaterScaled, AlphaCorrWaterScaledGroupNormed] = quantAlpha(metsName,amplMets, amplWater,getResults, metsTR, waterTR, metsTE, waterTE, fGM, fWM, fCSF, meanfGM, meanfWM,MRSCont.opts.fit.coMM3,Bo);
 
         % Save back to Osprey data container
         MRSCont.quantify.(getResults{1}).AlphaCorrWaterScaled{kk} = AlphaCorrWaterScaled;
@@ -487,7 +496,7 @@ end
 
 
 %%% Calculate raw water-scaled estimates %%%
-function rawWaterScaled = quantH2O(metsName, amplMets, amplWater, getResults, metsTR, waterTR, metsTE, waterTE)
+function rawWaterScaled = quantH2O(metsName, amplMets, amplWater, getResults, metsTR, waterTR, metsTE, waterTE,Bo)
 
 % Define constants
 PureWaterConc       = 55500;            % mmol/L
@@ -499,18 +508,30 @@ waterTR             = waterTR * 1e-3;   % convert to s
 
 % Look up relaxation times
 
-% Water
-% From Wansapura et al. 1999 (JMRI)
-%        T1          T2
-% WM   832 +/- 10  79.2 +/- 0.6
-% GM  1331 +/- 13  110 +/- 2
-T1_Water            = 1.100;            % average of WM and GM, Wansapura et al. 1999 (JMRI)
-T2_Water            = 0.095;            % average of WM and GM, Wansapura et al. 1999 (JMRI)
+switch Bo
+    case '3T'
+        % 3T Water
+        % From Wansapura et al. 1999 (JMRI)
+        %        T1          T2
+        % WM   832 +/- 10  79.2 +/- 0.6
+        % GM  1331 +/- 13  110 +/- 2
+        T1_Water            = 1.100;            % average of WM and GM, Wansapura et al. 1999 (JMRI)
+        T2_Water            = 0.095;            % average of WM and GM, Wansapura et al. 1999 (JMRI)
+        
+    case '7T'
+        % 7T Water
+        %        T1          T2
+        % WM    1220         50
+        % GM    2130         55
+        T1_Water            = 1.675;            % average of WM and GM, Rooney et al. 2007 (MRM)
+        T2_Water            = 0.0525;            % average of WM and GM, Bartha et al. 2002 (MRM)
+end
+
 
 % Metabolites
 for ll = 1:length(getResults)
     for kk = 1:length(metsName.(getResults{ll}))
-        [T1_Metab_GM(kk), T1_Metab_WM(kk), T2_Metab_GM(kk), T2_Metab_WM(kk)] = lookUpRelaxTimes(metsName.(getResults{1}){kk});
+        [T1_Metab_GM(kk), T1_Metab_WM(kk), T2_Metab_GM(kk), T2_Metab_WM(kk)] = lookUpRelaxTimes(metsName.(getResults{1}){kk},Bo);
         % average across GM and WM
         T1_Metab(kk) = mean([T1_Metab_GM(kk) T1_Metab_WM(kk)]);
         T2_Metab(kk) = mean([T2_Metab_GM(kk) T2_Metab_WM(kk)]);
@@ -542,30 +563,43 @@ end
 
 
 %%% Calculate tissue-corrected water-scaled estimates %%%
-function TissCorrWaterScaled = quantTiss(metsName, amplMets, amplWater, getResults, metsTR, waterTR, metsTE, waterTE, fGM, fWM, fCSF)
+function TissCorrWaterScaled = quantTiss(metsName, amplMets, amplWater, getResults, metsTR, waterTR, metsTE, waterTE, fGM, fWM, fCSF,Bo)
 % This function calculates water-scaled, tissue-corrected metabolite
 % estimates in molal units, according to Gasparovic et al, Magn Reson Med
 % 55:1219-26 (2006).
 
 % Define Constants
-% Water relaxation
-% From Lu et al. 2005 (JMRI)
-% CSF T1 = 3817 +/- 424msec - but state may underestimated and that 4300ms
-% is likely more accurate - but the reference is to an ISMRM 2001 abstract
-% MacKay (last author) 2006 ISMRM abstract has T1 CSF = 3300 ms
-% CSF T2 = 503.0 +/- 64.3 Piechnik MRM 2009; 61: 579
-% However, other values from Stanisz et al:
-% CPMG for T2, IR for T1
-% T2GM = 99 +/ 7, lit: 71+/- 10 (27)
-% T1GM = 1820 +/- 114, lit 1470 +/- 50 (29)
-% T2WM = 69 +/-3 lit 56 +/- 4 (27)
-% T1WM = 1084 +/- 45 lit 1110 +/- 45 (29)
-T1w_WM    = 0.832;
-T2w_WM    = 0.0792;
-T1w_GM    = 1.331;
-T2w_GM    = 0.110;
-T1w_CSF   = 3.817;
-T2w_CSF   = 0.503;
+switch Bo
+    case '3T'
+        % Water relaxation 3 T
+        % From Lu et al. 2005 (JMRI)
+        % CSF T1 = 3817 +/- 424msec - but state may underestimated and that 4300ms
+        % is likely more accurate - but the reference is to an ISMRM 2001 abstract
+        % MacKay (last author) 2006 ISMRM abstract has T1 CSF = 3300 ms
+        % CSF T2 = 503.0 +/- 64.3 Piechnik MRM 2009; 61: 579
+        % However, other values from Stanisz et al:
+        % CPMG for T2, IR for T1
+        % T2GM = 99 +/ 7, lit: 71+/- 10 (27)
+        % T1GM = 1820 +/- 114, lit 1470 +/- 50 (29)
+        % T2WM = 69 +/-3 lit 56 +/- 4 (27)
+        % T1WM = 1084 +/- 45 lit 1110 +/- 45 (29)
+        T1w_WM    = 0.832;
+        T2w_WM    = 0.0792;
+        T1w_GM    = 1.331;
+        T2w_GM    = 0.110;
+        T1w_CSF   = 3.817;
+        T2w_CSF   = 0.503;
+    case '7T'
+        % Water relaxation 7 T
+         % T1 from Rooney et al. 2007 (MRM)
+         % T2 from Bartha et al. 2002 (MRM)
+        T1w_WM    = 1.220;
+        T2w_WM    = 0.050;
+        T1w_GM    = 2.130;
+        T2w_GM    = 0.055;
+        T1w_CSF   = 4.425;
+        T2w_CSF   = 0.141;
+end
 
 % Determine concentration of water in GM, WM and CSF
 % Gasparovic et al. 2006 (MRM) uses relative densities, ref to
@@ -591,7 +625,7 @@ molal_fCSF = (fCSF*concW_CSF) ./ (fGM*concW_GM + fWM*concW_WM + fCSF*concW_CSF);
 % Metabolites
 for ll = 1:length(getResults)
     for kk = 1:length(metsName.(getResults{ll}))
-        [T1_Metab_GM(kk), T1_Metab_WM(kk), T2_Metab_GM(kk), T2_Metab_WM(kk)] = lookUpRelaxTimes(metsName.(getResults{1}){kk});
+        [T1_Metab_GM(kk), T1_Metab_WM(kk), T2_Metab_GM(kk), T2_Metab_WM(kk)] = lookUpRelaxTimes(metsName.(getResults{1}){kk},Bo);
         % average across GM and WM
         T1_Metab(kk) = mean([T1_Metab_GM(kk) T1_Metab_WM(kk)]);
         T2_Metab(kk) = mean([T2_Metab_GM(kk) T2_Metab_WM(kk)]);
@@ -611,30 +645,43 @@ end
 
 
 %%% Calculate alpha-corrected water-scaled GABA estimates %%%
-function [AlphaCorrWaterScaled, AlphaCorrWaterScaledGroupNormed] = quantAlpha(metsName, amplMets, amplWater,getResults, metsTR, waterTR, metsTE, waterTE, fGM, fWM, fCSF, meanfGM, meanfWM,coMM3)
+function [AlphaCorrWaterScaled, AlphaCorrWaterScaledGroupNormed] = quantAlpha(metsName, amplMets, amplWater,getResults, metsTR, waterTR, metsTE, waterTE, fGM, fWM, fCSF, meanfGM, meanfWM,coMM3,Bo)
 % This function calculates water-scaled, alpha-corrected GABA
 % estimates in molal units, according to Gasparovic et al, Magn Reson Med
 % 55:1219-26 (2006).
 
 % Define Constants
-% Water relaxation
-% From Lu et al. 2005 (JMRI)
-% CSF T1 = 3817 +/- 424msec - but state may underestimated and that 4300ms
-% is likely more accurate - but the reference is to an ISMRM 2001 abstract
-% MacKay (last author) 2006 ISMRM abstract has T1 CSF = 3300 ms
-% CSF T2 = 503.0 +/- 64.3 Piechnik MRM 2009; 61: 579
-% However, other values from Stanisz et al:
-% CPMG for T2, IR for T1
-% T2GM = 99 +/ 7, lit: 71+/- 10 (27)
-% T1GM = 1820 +/- 114, lit 1470 +/- 50 (29)
-% T2WM = 69 +/-3 lit 56 +/- 4 (27)
-% T1WM = 1084 +/- 45 lit 1110 +/- 45 (29)
-T1w_WM    = 0.832;
-T2w_WM    = 0.0792;
-T1w_GM    = 1.331;
-T2w_GM    = 0.110;
-T1w_CSF   = 3.817;
-T2w_CSF   = 0.503;
+switch Bo
+    case '3T'
+        % Water relaxation 3 T
+        % From Lu et al. 2005 (JMRI)
+        % CSF T1 = 3817 +/- 424msec - but state may underestimated and that 4300ms
+        % is likely more accurate - but the reference is to an ISMRM 2001 abstract
+        % MacKay (last author) 2006 ISMRM abstract has T1 CSF = 3300 ms
+        % CSF T2 = 503.0 +/- 64.3 Piechnik MRM 2009; 61: 579
+        % However, other values from Stanisz et al:
+        % CPMG for T2, IR for T1
+        % T2GM = 99 +/ 7, lit: 71+/- 10 (27)
+        % T1GM = 1820 +/- 114, lit 1470 +/- 50 (29)
+        % T2WM = 69 +/-3 lit 56 +/- 4 (27)
+        % T1WM = 1084 +/- 45 lit 1110 +/- 45 (29)
+        T1w_WM    = 0.832;
+        T2w_WM    = 0.0792;
+        T1w_GM    = 1.331;
+        T2w_GM    = 0.110;
+        T1w_CSF   = 3.817;
+        T2w_CSF   = 0.503;
+    case '7T'
+        % Water relaxation 7 T
+         % T1 from Rooney et al. 2007 (MRM)
+         % T2 from Bartha et al. 2002 (MRM)
+        T1w_WM    = 1.220;
+        T2w_WM    = 0.050;
+        T1w_GM    = 2.130;
+        T2w_GM    = 0.055;
+        T1w_CSF   = 4.425;
+        T2w_CSF   = 0.141;
+end
 
 % Determine concentration of water in GM, WM and CSF
 % Gasparovic et al. 2006 (MRM) uses relative densities, ref to
@@ -658,7 +705,7 @@ CorrFactor = (meanfGM + alpha.*meanfWM) ./ ((fGM + alpha.*fWM) .* (meanfGM + mea
 
 % GABA (Harris et al, J Magn Reson Imaging 42:1431-1440 (2015))
 idx_GABA  = find(strcmp(metsName.(getResults{1}),'GABA'));
-[T1_Metab_GM, T1_Metab_WM, T2_Metab_GM, T2_Metab_WM] = lookUpRelaxTimes(metsName.(getResults{1}){idx_GABA});
+[T1_Metab_GM, T1_Metab_WM, T2_Metab_GM, T2_Metab_WM] = lookUpRelaxTimes(metsName.(getResults{1}){idx_GABA},Bo);
 % average across GM and WM
 T1_Metab = mean([T1_Metab_GM T1_Metab_WM]);
 T2_Metab = mean([T2_Metab_GM T2_Metab_WM]);
@@ -673,7 +720,7 @@ AlphaCorrWaterScaledGroupNormed = ConcIU_TissCorr_Harris .* CorrFactor;
 if ~strcmp(coMM3, 'none')
     % GABA (Harris et al, J Magn Reson Imaging 42:1431-1440 (2015))
     idx_GABAp  = find(strcmp(metsName.(getResults{1}),'GABAplus'));
-    [T1_Metab_GM, T1_Metab_WM, T2_Metab_GM, T2_Metab_WM] = lookUpRelaxTimes(metsName.(getResults{1}){idx_GABA});
+    [T1_Metab_GM, T1_Metab_WM, T2_Metab_GM, T2_Metab_WM] = lookUpRelaxTimes(metsName.(getResults{1}){idx_GABA},Bo);
     % average across GM and WM
     T1_Metab = mean([T1_Metab_GM T1_Metab_WM]);
     T2_Metab = mean([T2_Metab_GM T2_Metab_WM]);
@@ -691,51 +738,96 @@ end
 
 
 %%% Lookup function for metabolite relaxation times %%%
-function [T1_GM, T1_WM, T2_GM, T2_WM] = lookUpRelaxTimes(metName)
+function [T1_GM, T1_WM, T2_GM, T2_WM] = lookUpRelaxTimes(metName,Bo)
 
 % Look up table below
-% T1 values for NAA, Glu, Cr, Cho, Ins from Mlynarik et al, NMR Biomed
-% 14:325-331 (2001)
-% T1 for GABA from Puts et al, J Magn Reson Imaging 37:999-1003 (2013)
-% T2 values from Wyss et al, Magn Reson Med 80:452-461 (2018)
-% T2 values are averaged between OCC and pACC for GM; and PVWM for WM
-% Structure is [T1_GM T1_WM T2_GM T2_WM]
-relax.Asc   = [1340 1190 (125+105)/2 172];
-relax.Asp   = [1340 1190 (111+90)/2 148];
-relax.Cr    = [1460 1240 (148+144)/2 166]; % 3.03 ppm resonance; 3.92 ppm signal is taken care of by -CrCH2 during fitting
-relax.GABA  = [1310 1310 (102+75)/2 (102+75)/2]; % No WM estimate available; take GM estimate; both in good accordance with 88 ms reported by Edden et al
-relax.Glc   = [1340 1190 (117+88)/2 155]; % Glc1: [1310 1310 (128+90)/2 156];
-relax.Gln   = [1340 1190 (122+99)/2 168];
-relax.Glu   = [1270 1170 (135+122)/2 124];
-relax.Gly   = [1340 1190 (102+81)/2 152];
-relax.GPC   = [1300 1080 (274+222)/2 218]; % This is the Choline singlet (3.21 ppm, tcho2 in the paper); glycerol is tcho: [1310 1310 (257+213)/2 182]; % choline multiplet is tcho1: [1310 1310 (242+190)/2 178];
-relax.GSH   = [1340 1190 (100+77)/2 145]; % This is the cysteine signal (GSH1 in the paper), glycine is GSH: [1310 1310 (99+72)/2 145]; % glutamate is GSH2: [1310 1310 (102+76)/2 165];
-relax.Lac   = [1340 1190 (110+99)/2 159];
-relax.Ins   = [1230 1010 (244+229)/2 161];
-relax.NAA   = [1470 1350 (253+263)/2 343]; % This is the 2.008 ppm acetyl signal (naa in the paper); aspartyl is naa1: [1310 1310 (223+229)/2 310];
-relax.NAAG  = [1340 1190 (128+107)/2 185]; % This is the 2.042 ppm acetyl signal (naag in the paper); aspartyl is naag1: [1310 1310 (108+87)/2 180]; % glutamate is NAAG2: [1310 1310 (110+78)/2 157];
-relax.PCh   = [1300 1080 (274+221)/2 213]; % This is the singlet (3.20 ppm, tcho4 in the paper); multiple is tcho3: [1310 1310 (243+191)/2 178];
-relax.PCr   = [1460 1240 (148+144)/2 166]; % 3.03 ppm resonance; 3.92 ppm signal is taken care of by -CrCH2 during fitting; same as Cr
-relax.PE    = [1340 1190 (119+86)/2 158];
-relax.Scy   = [1340 1190 (125+107)/2 170];
-relax.Tau   = [1340 1190 (123+102)/2 (123+102)/2]; % No WM estimate available; take GM estimate
-relax.tNAA  = [(1470+1340)/2 (1350+1190)/2 (253+263+128+107)/4 (343+185)/2]; % Mean values from NAA + NAAG
-relax.tCr  = [(1460+1460)/2 (1240+1240)/2 (148+144+148+144)/4 (166+166)/2]; % Mean values from Cr + PCr
-relax.tCho  = [(1300+1080)/2 (1080+1080)/2 (274+222+274+221)/4 (218+213)/2]; % Mean values from GPC + PCh
-relax.Glx  = [(1340+1270)/2 (1190+1170)/2 (122+99+135+122)/4 (168+124)/2]; % Mean values from Glu + Glx
+switch Bo
+    case '3T'
+        % T1 values for NAA, Glu, Cr, Cho, Ins from Mlynarik et al, NMR Biomed
+        % 14:325-331 (2001)
+        % T1 for GABA from Puts et al, J Magn Reson Imaging 37:999-1003 (2013)
+        % T2 values from Wyss et al, Magn Reson Med 80:452-461 (2018)
+        % T2 values are averaged between OCC and pACC for GM; and PVWM for WM
+        % Structure is [T1_GM T1_WM T2_GM T2_WM]
+        relax.Asc   = [1340 1190 (125+105)/2 172];
+        relax.Asp   = [1340 1190 (111+90)/2 148];
+        relax.Cr    = [1460 1240 (148+144)/2 166]; % 3.03 ppm resonance; 3.92 ppm signal is taken care of by -CrCH2 during fitting
+        relax.GABA  = [1310 1310 (102+75)/2 (102+75)/2]; % No WM estimate available; take GM estimate; both in good accordance with 88 ms reported by Edden et al
+        relax.Glc   = [1340 1190 (117+88)/2 155]; % Glc1: [1310 1310 (128+90)/2 156];
+        relax.Gln   = [1340 1190 (122+99)/2 168];
+        relax.Glu   = [1270 1170 (135+122)/2 124];
+        relax.Gly   = [1340 1190 (102+81)/2 152];
+        relax.GPC   = [1300 1080 (274+222)/2 218]; % This is the Choline singlet (3.21 ppm, tcho2 in the paper); glycerol is tcho: [1310 1310 (257+213)/2 182]; % choline multiplet is tcho1: [1310 1310 (242+190)/2 178];
+        relax.GSH   = [1340 1190 (100+77)/2 145]; % This is the cysteine signal (GSH1 in the paper), glycine is GSH: [1310 1310 (99+72)/2 145]; % glutamate is GSH2: [1310 1310 (102+76)/2 165];
+        relax.Lac   = [1340 1190 (110+99)/2 159];
+        relax.Ins   = [1230 1010 (244+229)/2 161];
+        relax.NAA   = [1470 1350 (253+263)/2 343]; % This is the 2.008 ppm acetyl signal (naa in the paper); aspartyl is naa1: [1310 1310 (223+229)/2 310];
+        relax.NAAG  = [1340 1190 (128+107)/2 185]; % This is the 2.042 ppm acetyl signal (naag in the paper); aspartyl is naag1: [1310 1310 (108+87)/2 180]; % glutamate is NAAG2: [1310 1310 (110+78)/2 157];
+        relax.PCh   = [1300 1080 (274+221)/2 213]; % This is the singlet (3.20 ppm, tcho4 in the paper); multiple is tcho3: [1310 1310 (243+191)/2 178];
+        relax.PCr   = [1460 1240 (148+144)/2 166]; % 3.03 ppm resonance; 3.92 ppm signal is taken care of by -CrCH2 during fitting; same as Cr
+        relax.PE    = [1340 1190 (119+86)/2 158];
+        relax.Scy   = [1340 1190 (125+107)/2 170];
+        relax.Tau   = [1340 1190 (123+102)/2 (123+102)/2]; % No WM estimate available; take GM estimate
+        relax.tNAA  = [(1470+1340)/2 (1350+1190)/2 (253+263+128+107)/4 (343+185)/2]; % Mean values from NAA + NAAG
+        relax.tCr  = [(1460+1460)/2 (1240+1240)/2 (148+144+148+144)/4 (166+166)/2]; % Mean values from Cr + PCr
+        relax.tCho  = [(1300+1080)/2 (1080+1080)/2 (274+222+274+221)/4 (218+213)/2]; % Mean values from GPC + PCh
+        relax.Glx  = [(1340+1270)/2 (1190+1170)/2 (122+99+135+122)/4 (168+124)/2]; % Mean values from Glu + Glx
 
-% Check if metabolite name is in the look-up table
-if isfield(relax, metName)
-    T1_GM = relax.(metName)(1) * 1e-3;
-    T1_WM = relax.(metName)(2) * 1e-3;
-    T2_GM = relax.(metName)(3) * 1e-3;
-    T2_WM = relax.(metName)(4) * 1e-3;
-else
-    % If not, use an average
-    T1_GM = 1340 * 1e-3;
-    T1_WM = 1190 * 1e-3;
-    T2_GM = 140 * 1e-3;
-    T2_WM = 169 * 1e-3;
+        % Check if metabolite name is in the look-up table
+        if isfield(relax, metName)
+            T1_GM = relax.(metName)(1) * 1e-3;
+            T1_WM = relax.(metName)(2) * 1e-3;
+            T2_GM = relax.(metName)(3) * 1e-3;
+            T2_WM = relax.(metName)(4) * 1e-3;
+        else
+            % If not, use an average
+            T1_GM = 1340 * 1e-3;
+            T1_WM = 1190 * 1e-3;
+            T2_GM = 140 * 1e-3;
+            T2_WM = 169 * 1e-3;
+        end
+    case '7T'
+         % T2 values of water, NAA, tCr, tCho, Scyllo, Ins, Glu,GSH, Ins,
+         % and Tau are taken from Marjanska et al. 2011 (NMR
+         % 10.1002/nbm.1754). It was averaged across 4 regions OCC, SM1, BG, CER 
+         % Penner et al (2014) https://doi.org/10.1002/mrm.25380 for 
+        relax.Asc   = [1530 1484 127 128]; % This is the average from tNAA, tCr, tCho, Glx, and Ins
+        relax.Asp   = [1530 1484 127 128]; % This is the average from tNAA, tCr, tCho, Glx, and Ins
+        relax.Cr    = [1740 1780 107 107]; % Taken from tCr
+        relax.GABA  = [1334 1334 87 87]; % Andreychenko et al. (2012) 10.1002/nbm.2997
+        relax.Glc   = [1530 1484 127 128]; % This is the average from tNAA, tCr, tCho, Glx, and Ins 
+        relax.Gln   = [1640 1740 107 107]; %T1 from Mlynarik et al. (2012) 10.1002/mrm.24352 % T2 as Gln
+        relax.Glu   = [1610 1750 107 117]; % T1 from Mlynarik et al. (2012) 10.1002/mrm.24352, T2 from https://doi.org/10.1371/journal.pone.0215210
+        relax.Gly   = [1530 1484 127 128]; % This is the average from tNAA, tCr, tCho, Glx, and Ins
+        relax.GPC   = [1510 1320  153 153]; % Taken from tCho
+        relax.GSH   = [1140 1060 79 79]; % Entire molecule; T1 from Mlynarik et al. (2012) 10.1002/mrm.24352
+        relax.Lac   = [1530 1484 182 182]; % The use of MEGA-sLASER with J-refocusing echo time extension to measure the proton T2 of lactate in healthy human brain at 7 T ISMRM
+        relax.Ins   = [1280 1190 111 111]; %T1 from Mlynarik et al. (2012) 10.1002/mrm.24352
+        relax.NAA   = [1780 1830 155 155]; % This is the 2.008 ppm acetyl signal (naa in the paper); aspartyl is naa1: [1310 1310 110 110]; T1 from Mlynarik et al. (2012) 10.1002/mrm.24352
+        relax.NAAG  = [1210 940 155 155]; % This is the 2.042 ppm acetyl signal (naag in the paper); aspartyl is naag1: [1310 1310 (108+87)/2 180]; % glutamate is NAAG2: [1310 1310 (110+78)/2 157]; 
+        relax.PCh   = [1510 1320  153 153]; % Taken from tCho
+        relax.PCr   = [1740 1780 107 107]; % Taken from tCr
+        relax.PE    = [1310 1320]; %T1 from Mlynarik et al. (2012) 10.1002/mrm.24352
+        relax.Scy   = [1310 1230 105 105]; %T1 from Mlynarik et al. (2012) 10.1002/mrm.24352 T2 from https://onlinelibrary.wiley.com/doi/full/10.1002/mrm.24352
+        relax.Tau   = [2150 2090 97 97]; %T1 from Mlynarik et al. (2012) 10.1002/mrm.24352 % T2 as Gln
+        relax.tNAA  = [1495 1385 155 155]; % Mean values from NAA + NAAG
+        relax.tCr  = [1740 1780 107 107]; % The singlet peak ar 3 ppm. 3.9 ppm peak values are [1240 1190 94 94] %T1 from Mlynarik et al. (2012)
+        relax.tCho  = [1510 1320  153 153]; % Entire molecule; T1 from Mlynarik et al. (2012) 10.1002/mrm.24352
+        relax.Glx  = [1625 1745 107 112]; % Mean values from Glu + Glx
+
+        % Check if metabolite name is in the look-up table
+        if isfield(relax, metName)
+            T1_GM = relax.(metName)(1) * 1e-3;
+            T1_WM = relax.(metName)(2) * 1e-3;
+            T2_GM = relax.(metName)(3) * 1e-3;
+            T2_WM = relax.(metName)(4) * 1e-3;
+        else
+            % If not, use an average
+            T1_GM = 1530 * 1e-3; % This is the average from tNAA, tCr, tCho, Glx, and Ins
+            T1_WM = 1484 * 1e-3; % This is the average from tNAA, tCr, tCho, Glx, and Ins
+            T2_GM = 127 * 1e-3; % This is the average from tNAA, tCr, tCho, Glx, and Ins
+            T2_WM = 128 * 1e-3; % This is the average from tNAA, tCr, tCho, Glx, and Ins
+        end
 end
 
 end


### PR DESCRIPTION
- OspreyQuantify has now relaxation times for 7T metabolites as well
- fieldstrength is automatically picked