### PR TITLE
Decouple MRS container from local machine

### DIFF
--- a/GUI/OspreyGUI.m
+++ b/GUI/OspreyGUI.m
@@ -68,10 +68,21 @@ classdef OspreyGUI < handle
         %% Initialize variables
         % Close any remaining open figures & add folders
             close all;
-            diary(fullfile(MRSCont.outputFolder, 'LogFile.txt'));
             [settingsFolder,~,~] = fileparts(which('OspreySettings.m'));
             gui.folder.allFolders      = strsplit(settingsFolder, filesep);
             gui.folder.ospFolder       = strjoin(gui.folder.allFolders(1:end-1), filesep); % parent folder (= Osprey folder)
+            MRSCont.flags.moved = 0;
+            if isfile(fullfile(MRSCont.outputFolder, 'LogFile.txt'))
+                MRSCont.flags.moved = 0;
+                diary(fullfile(MRSCont.outputFolder, 'LogFile.txt'));
+            else %The MRSContainer has been moved, so we will store the the diary in the GUI folder
+                diary(fullfile(gui.folder.ospFolder, 'LogFile.txt'));
+                MRSCont.flags.moved = 1;
+                if (isfield(MRSCont.flags,'addImages') && (MRSCont.flags.addImages == 0))
+                    MRSCont.flags.didCoreg = 0;
+                    MRSCont.flags.didSeg = 0;
+                end
+            end
             diary off
         % Toolbox check
             if isfield(MRSCont.flags,'isToolChecked')
@@ -337,8 +348,10 @@ classdef OspreyGUI < handle
         % Coregister button
             gui.layout.b_coreg = uicontrol('Parent', gui.layout.p2,'Style','PushButton','String','CoRegister','Enable','off','ForegroundColor', gui.colormap.Foreground);
             set(gui.layout.b_coreg,'Units','Normalized','Position',[0.1 0.59 0.8 0.08], 'FontSize', 16, 'FontName', 'Arial', 'FontWeight', 'Bold');
-            if MRSCont.flags.hasSPM == 1 && ~isempty(MRSCont.files_nii) && ~(MRSCont.flags.didCoreg == 1  && isfield(MRSCont, 'coreg') && (gui.controls.nDatasets >= length(MRSCont.coreg.vol_image))) && (MRSCont.flags.didLoadData == 1  && isfield(MRSCont, 'raw') && (gui.controls.nDatasets >= length(MRSCont.raw)))
-                gui.layout.b_coreg.Enable = 'on';
+            if MRSCont.flags.hasSPM == 1 && ~isempty(MRSCont.files_nii) && ~(MRSCont.flags.didCoreg == 1  && isfield(MRSCont, 'coreg') && (gui.controls.nDatasets >= length(MRSCont.coreg.vol_image))) && (MRSCont.flags.didLoadData == 1  && isfield(MRSCont, 'raw') && (gui.controls.nDatasets >= length(MRSCont.raw)))               
+                if ~(isfield(MRSCont.flags,'addImages') && (MRSCont.flags.addImages == 0) && MRSCont.flags.moved)
+                    gui.layout.b_coreg.Enable = 'on';
+                end
             end
             set(gui.layout.b_coreg,'Callback',{@osp_onCoreg,gui}, 'TooltipString', 'Call OspreyCoreg');
             if MRSCont.flags.hasSPM == 0
@@ -348,7 +361,9 @@ classdef OspreyGUI < handle
             gui.layout.b_segm = uicontrol('Parent', gui.layout.p2,'Style','PushButton','String','Segment','Enable','off','ForegroundColor', gui.colormap.Foreground);
             set(gui.layout.b_segm,'Units','Normalized','Position',[0.1 0.51 0.8 0.08], 'FontSize', 16, 'FontName', 'Arial', 'FontWeight', 'Bold');
             if MRSCont.flags.hasSPM == 1 && ~isempty(MRSCont.files_nii) && ~(MRSCont.flags.didSeg == 1  && isfield(MRSCont, 'seg') && (gui.controls.nDatasets >= length(MRSCont.seg.tissue.fGM(:,1)))) && (MRSCont.flags.didCoreg == 1  && isfield(MRSCont, 'coreg') && (gui.controls.nDatasets >= length(MRSCont.coreg.vol_image)))
-                gui.layout.b_segm.Enable = 'on';
+                if ~(isfield(MRSCont.flags,'addImages') && (MRSCont.flags.addImages == 0) && MRSCont.flags.moved)
+                    gui.layout.b_segm.Enable = 'on';
+                end
             end
             set(gui.layout.b_segm,'Callback',{@osp_onSeg,gui}, 'TooltipString', 'Call OspreySeg');
             if MRSCont.flags.hasSPM == 0
@@ -380,7 +395,9 @@ classdef OspreyGUI < handle
             gui.layout.controlPanel = uix.Panel('Parent', gui.layout.leftMenu, 'Title', 'MRS Container','BackgroundColor',gui.colormap.Background);
             set(gui.layout.controlPanel,'Units','Normalized','Position',[0.5 0 0.66 0.1], 'FontSize', 16, 'FontName', 'Arial', 'FontWeight', 'Bold', 'ForegroundColor',gui.colormap.Foreground, 'HighlightColor',gui.colormap.Foreground, 'ShadowColor',gui.colormap.Foreground);
             gui.layout.fileList = MRSCont.files;
-            [~, ~] = osp_detDataType(MRSCont);
+            if ~MRSCont.flags.moved
+                [~, ~] = osp_detDataType(MRSCont);
+            end
             SepFileList = cell(1,length(MRSCont.files));
             gui.layout.RedFileList = cell(1,length(MRSCont.files));
             gui.layout.OnlyFileList = cell(1,length(MRSCont.files));

--- a/GUI/osp_onNii.m
+++ b/GUI/osp_onNii.m
@@ -27,24 +27,28 @@ function osp_onNii( ~, ~,gui)
 %
 
     fprintf('Opening external nii viever...\n');
-    MRSCont = getappdata(gui.figure,'MRSCont'); % Get MRSCont from hidden container in gui class    
-    if  ~((isfield(MRSCont.flags, 'isPRIAM') || isfield(MRSCont.flags, 'isMRSI')) &&  (MRSCont.flags.isPRIAM || MRSCont.flags.isMRSI))
-        if exist(MRSCont.coreg.vol_mask{gui.controls.Selected}.fname, 'file')
-            nii_viewer(MRSCont.files_nii{gui.controls.Selected}, MRSCont.coreg.vol_mask{gui.controls.Selected}.fname);
-        else if exist([MRSCont.coreg.vol_mask{gui.controls.Selected}.fname, '.gz'], 'file')
-            nii_viewer(MRSCont.files_nii{gui.controls.Selected}, [MRSCont.coreg.vol_mask{gui.controls.Selected}.fname, '.gz']);
+    MRSCont = getappdata(gui.figure,'MRSCont'); % Get MRSCont from hidden container in gui class 
+    if ~(isfield(MRSCont.flags,'addImages') && (MRSCont.flags.addImages == 1) && MRSCont.flags.moved)
+        if  ~((isfield(MRSCont.flags, 'isPRIAM') || isfield(MRSCont.flags, 'isMRSI')) &&  (MRSCont.flags.isPRIAM || MRSCont.flags.isMRSI))
+            if exist(MRSCont.coreg.vol_mask{gui.controls.Selected}.fname, 'file')
+                nii_viewer(MRSCont.files_nii{gui.controls.Selected}, MRSCont.coreg.vol_mask{gui.controls.Selected}.fname);
+            else if exist([MRSCont.coreg.vol_mask{gui.controls.Selected}.fname, '.gz'], 'file')
+                nii_viewer(MRSCont.files_nii{gui.controls.Selected}, [MRSCont.coreg.vol_mask{gui.controls.Selected}.fname, '.gz']);
+                end
             end
+        else
+            if exist(MRSCont.coreg.vol_mask{gui.controls.Selected}{1}.fname, 'file')
+                 nii_viewer(MRSCont.files_nii{gui.controls.Selected}, {MRSCont.coreg.vol_mask{gui.controls.Selected}{1}.fname,MRSCont.coreg.vol_mask{gui.controls.Selected}{2}.fname})
+            else if exist([MRSCont.coreg.vol_mask{gui.controls.Selected}{1}.fname, '.gz'], 'file')
+                 nii_viewer(MRSCont.files_nii{gui.controls.Selected}, {[MRSCont.coreg.vol_mask{gui.controls.Selected}{1}.fname, '.gz'],[MRSCont.coreg.vol_mask{gui.controls.Selected}{2}.fname, '.gz']})
+                end
+            end
+
         end
+        fprintf('... done.\n');
     else
-        if exist(MRSCont.coreg.vol_mask{gui.controls.Selected}{1}.fname, 'file')
-             nii_viewer(MRSCont.files_nii{gui.controls.Selected}, {MRSCont.coreg.vol_mask{gui.controls.Selected}{1}.fname,MRSCont.coreg.vol_mask{gui.controls.Selected}{2}.fname})
-        else if exist([MRSCont.coreg.vol_mask{gui.controls.Selected}{1}.fname, '.gz'], 'file')
-             nii_viewer(MRSCont.files_nii{gui.controls.Selected}, {[MRSCont.coreg.vol_mask{gui.controls.Selected}{1}.fname, '.gz'],[MRSCont.coreg.vol_mask{gui.controls.Selected}{2}.fname, '.gz']})
-            end
-        end
-        
+        fprintf('The MRS container has been moved and you have no access to the nifti files anymore.\n');
     end
-    fprintf('... done.\n');
     setappdata(gui.figure,'MRSCont',MRSCont); % Write MRSCont into hidden container in gui class
 
 end % osp_onNii

--- a/coreg/OspreyCoreg.m
+++ b/coreg/OspreyCoreg.m
@@ -155,11 +155,18 @@ for kk = 1:MRSCont.nDatasets
         MRSCont.coreg.T1_max{kk}    = T1_max;
         MRSCont.coreg.voxel_ctr{kk} = voxel_ctr;
         
+        if MRSCont.flags.addImages
+            [MRSCont.coreg.three_plane_img{kk}] = osp_extract_three_plane_image(vol_image, vol_mask,voxel_ctr,T1_max);
+        end
+        
         %Delete .nii file if a .nii.gz
          if strcmp(T1ext,'.gz')
             delete(MRSCont.files_nii{kk});
             MRSCont.files_nii{kk} = strrep(MRSCont.files_nii{kk},'.nii','.nii.gz');
-        end
+         end
+         gzip(vol_mask.fname);
+         delete(vol_mask.fname);
+            
     end
 end
 time = toc(refCoregTime);

--- a/coreg/coreg_ge_nifti.m
+++ b/coreg/coreg_ge_nifti.m
@@ -143,8 +143,6 @@ vol_mask.descrip = 'MRS_voxel_mask';
 
 % Write the SPM volume to disk
 vol_mask = spm_write_vol(vol_mask,mask);
-gzip(vol_mask.fname);
-delete(vol_mask.fname);
 
 % Store voxel centre for output figure
 % VoxOffs(1:2) = -VoxOffs(1:2); Apparently, this is not necessary for GE

--- a/coreg/coreg_p.m
+++ b/coreg/coreg_p.m
@@ -214,8 +214,6 @@ vol_mask.descrip = 'MRS_voxel_mask';
 
 % Write the SPM volume to disk
 vol_mask = spm_write_vol(vol_mask,mask);
-gzip(vol_mask.fname);
-delete(vol_mask.fname);
 
 % Store voxel centre for output figure
 VoxOffs(1:2) = -VoxOffs(1:2);

--- a/coreg/coreg_sdat.m
+++ b/coreg/coreg_sdat.m
@@ -191,12 +191,8 @@ for rr = 1:size(vox_ctr_coor,3)
     % Write the SPM volume to disk
     if ~isstruct(DualVoxel) 
         vol_mask = spm_write_vol(vol_mask,mask);
-        gzip(vol_mask.fname);
-        delete(vol_mask.fname);
     else % For PRIAM data store two voxel masks
         vol_mask_out{rr} = spm_write_vol(vol_mask,mask);
-        gzip(vol_mask.fname);
-        delete(vol_mask.fname);
     end
 
     % Store voxel centre for output figure

--- a/coreg/coreg_siemens.m
+++ b/coreg/coreg_siemens.m
@@ -187,8 +187,6 @@ vol_mask.descrip = 'MRS_voxel_mask';
 
 % Write the SPM volume to disk
 vol_mask = spm_write_vol(vol_mask,mask);
-gzip(vol_mask.fname);
-delete(vol_mask.fname);
 
 % Store voxel centre for output figure
 voxel_ctr = [VoxOffs(1) VoxOffs(2) VoxOffs(3)];

--- a/coreg/osp_extract_three_plane_image.m
+++ b/coreg/osp_extract_three_plane_image.m
@@ -1,0 +1,49 @@
+% osp_extract_three_plane_image.m
+% Helge Zoellner, Johns Hopkins University 2021.
+%
+% USAGE:
+% [three_plane_image] = osp_extract_three_plane_image(ImageFile, MaskFile);
+%
+% DESCRIPTION:
+% Creates a SPM volume containing a voxel mask with the same dimensions
+% as the SPM volume containing a structural image. The voxel mask will be
+% created with the geometry information stored in the FID-A structure "in".
+% This routine works for the GE P data type.
+
+% INPUTS:
+% ImageFile   = Path to Image File (NifTI).
+% MaskFile    = Path to Mask Volume (NifTI).
+% VoxelIndex  = Voxel index for PRIAM
+%
+% OUTPUTS:
+% three_plane_img  = three plane image for plots and GUI.
+
+
+function [three_plane_img] = osp_extract_three_plane_image(ImageFile, MaskFile,voxel_ctr,T1_max);
+%%% 1. LOAD IMAGE AND MASK VOLUME %%%
+
+    Vimage=spm_vol(ImageFile);
+    Vmask=spm_vol(MaskFile);    
+
+    %%% 2. SET UP THREE PLANE IMAGE %%%
+    % Generate three plane image for the output
+    % Transform structural image and co-registered voxel mask from voxel to
+    % world space for output (MM: 180221)
+
+    [img_t,img_c,img_s] = voxel2world_space(Vimage,voxel_ctr);
+    [mask_t,mask_c,mask_s] = voxel2world_space(Vmask,voxel_ctr);
+
+    img_t = flipud(img_t/T1_max);
+    img_c = flipud(img_c/T1_max);
+    img_s = flipud(img_s/T1_max);
+
+    img_t = img_t + 0.225*flipud(mask_t);
+    img_c = img_c + 0.225*flipud(mask_c);
+    img_s = img_s + 0.225*flipud(mask_s);
+
+    size_max = max([max(size(img_t)) max(size(img_c)) max(size(img_s))]);
+    three_plane_img = zeros([size_max 3*size_max]);
+    three_plane_img(:,1:size_max)              = image_center(img_t, size_max);
+    three_plane_img(:,size_max+(1:size_max))   = image_center(img_s, size_max);
+    three_plane_img(:,size_max*2+(1:size_max)) = image_center(img_c, size_max);
+end

--- a/plot/osp_plotSegment.m
+++ b/plot/osp_plotSegment.m
@@ -43,28 +43,12 @@ end
 % Get the input file name
 [path_voxel,filename_voxel,fileext_voxel]   = fileparts(MRSCont.files{kk});
 [~,filename_image,fileext_image]   = fileparts(MRSCont.coreg.vol_image{kk}.fname);
-% For batch analysis, get the last two sub-folders (e.g. site and
-% subject)
-path_split          = regexp(path_voxel,filesep,'split');
-if length(path_split) > 2
-    saveName = [path_split{end-1} '_' path_split{end} '_' filename_voxel];
-end
-
-segDestination = fullfile(MRSCont.outputFolder, 'SegMaps');
-
-VoxelNum = ['_Voxel_' num2str(VoxelIndex)];
-
-GM  = fullfile(segDestination, [saveName VoxelNum '_GM.nii']);
-WM  = fullfile(segDestination, [saveName VoxelNum '_WM.nii']);
-CSF = fullfile(segDestination, [saveName VoxelNum '_CSF.nii']);
-
-if exist([GM '.gz'], 'file')
-    gunzip([GM '.gz']);
-    gunzip([WM '.gz']);
-    gunzip([CSF '.gz']);
-else
+if ~(isfield(MRSCont.flags,'addImages') && (MRSCont.flags.addImages == 1))
+    % For batch analysis, get the last two sub-folders (e.g. site and
+    % subject)
+    path_split          = regexp(path_voxel,filesep,'split');
     if length(path_split) > 2
-        saveName = ['jobServer_' path_split{end} '_' filename_voxel];
+        saveName = [path_split{end-1} '_' path_split{end} '_' filename_voxel];
     end
 
     segDestination = fullfile(MRSCont.outputFolder, 'SegMaps');
@@ -74,63 +58,67 @@ else
     GM  = fullfile(segDestination, [saveName VoxelNum '_GM.nii']);
     WM  = fullfile(segDestination, [saveName VoxelNum '_WM.nii']);
     CSF = fullfile(segDestination, [saveName VoxelNum '_CSF.nii']);
+
     if exist([GM '.gz'], 'file')
         gunzip([GM '.gz']);
         gunzip([WM '.gz']);
         gunzip([CSF '.gz']);
+    else
+        if length(path_split) > 2
+            saveName = ['jobServer_' path_split{end} '_' filename_voxel];
+        end
+
+        segDestination = fullfile(MRSCont.outputFolder, 'SegMaps');
+
+        VoxelNum = ['_Voxel_' num2str(VoxelIndex)];
+
+        GM  = fullfile(segDestination, [saveName VoxelNum '_GM.nii']);
+        WM  = fullfile(segDestination, [saveName VoxelNum '_WM.nii']);
+        CSF = fullfile(segDestination, [saveName VoxelNum '_CSF.nii']);
+        if exist([GM '.gz'], 'file')
+            gunzip([GM '.gz']);
+            gunzip([WM '.gz']);
+            gunzip([CSF '.gz']);
+        end
     end
-end
 
-if ~exist(GM, 'file') % This is just for combability of older Osprey versions
-    GM  = fullfile(segDestination, [saveName '_GM.nii']);
-    WM  = fullfile(segDestination, [saveName '_WM.nii']);
-    CSF = fullfile(segDestination, [saveName '_CSF.nii']);
-end
+    if ~exist(GM, 'file') % This is just for combability of older Osprey versions
+        GM  = fullfile(segDestination, [saveName '_GM.nii']);
+        WM  = fullfile(segDestination, [saveName '_WM.nii']);
+        CSF = fullfile(segDestination, [saveName '_CSF.nii']);
+    end
 
-vol_GM_mask  = spm_vol(GM);
-vol_WM_mask  = spm_vol(WM);
-vol_CSF_mask = spm_vol(CSF);
+    vol_GM_mask  = spm_vol(GM);
+    vol_WM_mask  = spm_vol(WM);
+    vol_CSF_mask = spm_vol(CSF);
 
- [~, ~, T1ext]  = fileparts(MRSCont.coreg.vol_image{kk}.fname);
-if strcmp(T1ext, '.gz') && ~exist(MRSCont.coreg.vol_image{kk}.fname,'file') 
-    gunzip(MRSCont.coreg.vol_image{kk}.fname)
-end
+     [~, ~, T1ext]  = fileparts(MRSCont.coreg.vol_image{kk}.fname);
+    if strcmp(T1ext, '.gz') && ~exist(MRSCont.coreg.vol_image{kk}.fname,'file') 
+        gunzip(MRSCont.coreg.vol_image{kk}.fname)
+    end
 
-Vimage=spm_vol(MRSCont.coreg.vol_image{kk}.fname);
+    %%% 3. SET UP THREE PLANE IMAGE %%%
+    if ~(isfield(MRSCont.flags,'isPRIAM') && (MRSCont.flags.isPRIAM == 1))
+        [img_montage,vox_t_size] = osp_extract_three_plane_image_seg(MRSCont.coreg.vol_image{kk}.fname, MRSCont.coreg.vol_mask{kk}.fname,vol_GM_mask,vol_WM_mask,vol_CSF_mask,MRSCont.coreg.voxel_ctr{kk},MRSCont.coreg.T1_max{kk});
+    else
+        [img_montage,vox_t_size] = osp_extract_three_plane_image_seg(MRSCont.coreg.vol_image{kk}.fname, MRSCont.coreg.vol_mask{kk}{VoxelIndex}.fname,vol_GM_mask,vol_WM_mask,vol_CSF_mask,MRSCont.coreg.voxel_ctr{kk}(:,:,VoxelIndex),MRSCont.coreg.T1_max{kk});
+    end
 
-if ~(isfield(MRSCont.flags,'isPRIAM') && (MRSCont.flags.isPRIAM == 1))
-    Vmask=spm_vol(MRSCont.coreg.vol_mask{kk}.fname);    
-    voxel_ctr = MRSCont.coreg.voxel_ctr{kk};
+
+    if exist([GM, '.gz'],'file')
+        delete(GM);
+        delete(WM);
+        delete(CSF);
+    end
+    if exist([MRSCont.coreg.vol_image{kk}.fname, '.gz'],'file')
+        delete(MRSCont.coreg.vol_image{kk}.fname);
+    end
+    if exist([MRSCont.coreg.vol_mask{kk}.fname, '.gz'],'file')
+        delete(MRSCont.coreg.vol_mask{kk}.fname);
+    end
 else
-    Vmask=spm_vol(MRSCont.coreg.vol_mask{kk}{VoxelIndex}.fname);    
-    voxel_ctr = MRSCont.coreg.voxel_ctr{kk}(:,:,VoxelIndex); 
-end
-
-
-
-%%% 3. SET UP THREE PLANE IMAGE %%%
-% Generate three plane image for the output
-% Transform structural image and co-registered voxel mask from voxel to
-% world space for output (MM: 180221)
-img_t     = flipud(voxel2world_space(Vimage, voxel_ctr));
-vox_t     = flipud(voxel2world_space(Vmask, voxel_ctr));
-vox_t_GM  = flipud(voxel2world_space(vol_GM_mask, voxel_ctr));
-vox_t_WM  = flipud(voxel2world_space(vol_WM_mask, voxel_ctr));
-vox_t_CSF = flipud(voxel2world_space(vol_CSF_mask, voxel_ctr));
-img_t = img_t/MRSCont.coreg.T1_max{kk};
-img_montage = [img_t+0.225*vox_t, img_t+0.3*vox_t_GM, img_t+0.225*vox_t_WM, img_t+0.4*vox_t_CSF];
-
-
-if exist([GM, '.gz'],'file')
-    delete(GM);
-    delete(WM);
-    delete(CSF);
-end
-if exist([MRSCont.coreg.vol_image{kk}.fname, '.gz'],'file')
-    delete(MRSCont.coreg.vol_image{kk}.fname);
-end
-if exist([MRSCont.coreg.vol_mask{kk}.fname, '.gz'],'file')
-    delete(MRSCont.coreg.vol_mask{kk}.fname);
+    img_montage = MRSCont.seg.img_montage{kk};
+    vox_t_size = MRSCont.seg.size_vox_t(kk);
 end
 %%% 4. SET UP FIGURE LAYOUT %%%
 % Generate a new figure and keep the handle memorized
@@ -141,10 +129,10 @@ else
     out = figure('Visible','off');
 end
 imagesc(img_montage);
-text(floor(size(vox_t,2)/2), 15, 'Voxel', 'Color', MRSCont.colormap.Background, 'FontSize', 14, 'HorizontalAlignment', 'center');
-text(floor(size(vox_t,2)) + floor(size(vox_t,2)/2), 15, 'GM', 'Color', MRSCont.colormap.Background, 'FontSize', 14, 'HorizontalAlignment', 'center');
-text(2*floor(size(vox_t,2)) + floor(size(vox_t,2)/2), 15, 'WM', 'Color', MRSCont.colormap.Background, 'FontSize', 14, 'HorizontalAlignment', 'center');
-text(3*floor(size(vox_t,2)) + floor(size(vox_t,2)/2), 15, 'CSF', 'Color', MRSCont.colormap.Background, 'FontSize', 14, 'HorizontalAlignment', 'center');
+text(floor(vox_t_size/2), 15, 'Voxel', 'Color', MRSCont.colormap.Background, 'FontSize', 14, 'HorizontalAlignment', 'center');
+text(floor(vox_t_size) + floor(vox_t_size/2), 15, 'GM', 'Color', MRSCont.colormap.Background, 'FontSize', 14, 'HorizontalAlignment', 'center');
+text(2*floor(vox_t_size) + floor(vox_t_size/2), 15, 'WM', 'Color', MRSCont.colormap.Background, 'FontSize', 14, 'HorizontalAlignment', 'center');
+text(3*floor(vox_t_size) + floor(vox_t_size/2), 15, 'CSF', 'Color', MRSCont.colormap.Background, 'FontSize', 14, 'HorizontalAlignment', 'center');
 colormap('gray');
 caxis([0 1])
 axis equal;
@@ -166,13 +154,13 @@ end
 
 
 %%% 5. ADD TISSUE COMPOSITION %%%
-text(floor(size(vox_t,2)/2), size(img_montage,1)-15, 'voxel fraction', 'Color', MRSCont.colormap.Background, 'FontSize', 14, 'HorizontalAlignment', 'center');
+text(floor(vox_t_size/2), size(img_montage,1)-15, 'voxel fraction', 'Color', MRSCont.colormap.Background, 'FontSize', 14, 'HorizontalAlignment', 'center');
 tmp1 = sprintf('%.2f', MRSCont.seg.tissue.fGM(kk,VoxelIndex));
-text(floor(size(vox_t,2)) + floor(size(vox_t,2)/2), size(img_montage,1)-15, tmp1, 'Color', MRSCont.colormap.Background, 'FontSize', 14, 'HorizontalAlignment', 'center');
+text(floor(vox_t_size) + floor(vox_t_size/2), size(img_montage,1)-15, tmp1, 'Color', MRSCont.colormap.Background, 'FontSize', 14, 'HorizontalAlignment', 'center');
 tmp1 = sprintf('%.2f', MRSCont.seg.tissue.fWM(kk,VoxelIndex));
-text(2*floor(size(vox_t,2)) + floor(size(vox_t,2)/2), size(img_montage,1)-15, tmp1, 'Color', MRSCont.colormap.Background, 'FontSize', 14, 'HorizontalAlignment', 'center');
+text(2*floor(vox_t_size) + floor(vox_t_size/2), size(img_montage,1)-15, tmp1, 'Color', MRSCont.colormap.Background, 'FontSize', 14, 'HorizontalAlignment', 'center');
 tmp1 = sprintf('%.2f', MRSCont.seg.tissue.fCSF(kk,VoxelIndex));
-text(3*floor(size(vox_t,2)) + floor(size(vox_t,2)/2), size(img_montage,1)-15, tmp1, 'Color', MRSCont.colormap.Background, 'FontSize', 14, 'HorizontalAlignment', 'center');
+text(3*floor(vox_t_size) + floor(vox_t_size/2), size(img_montage,1)-15, tmp1, 'Color', MRSCont.colormap.Background, 'FontSize', 14, 'HorizontalAlignment', 'center');
 
 %%% 6. ADD OSPREY LOGO %%%
 if ~MRSCont.flags.isGUI

--- a/seg/OspreySeg.m
+++ b/seg/OspreySeg.m
@@ -241,6 +241,11 @@ for kk = 1:MRSCont.nDatasets
             WMsum  = sum(sum(sum(vol_WMMask.private.dat(:,:,:))));
             CSFsum = sum(sum(sum(vol_CSFMask.private.dat(:,:,:))));
             
+            % Save three plane image to container
+            if MRSCont.flags.addImages                
+                [MRSCont.seg.img_montage{kk},MRSCont.seg.size_vox_t(kk)] = osp_extract_three_plane_image_seg(niftiFile, vol_mask,vol_GMMask,vol_WMMask,vol_CSFMask,MRSCont.coreg.voxel_ctr{kk},MRSCont.coreg.T1_max{kk});
+            end
+            
             %Compress nifit and delete uncompressed files
             gzip(vol_GMMask.fname);
             delete(vol_GMMask.fname);
@@ -255,8 +260,8 @@ for kk = 1:MRSCont.nDatasets
             gzip(CSFvol.fname);
             delete(CSFvol.fname);
             delete(vol_mask.fname);
-            gzip(niftiFile)
-            delete(vol_mask.fname);
+            gzip(MRSCont.coreg.vol_image{kk}.fname)
+            delete(MRSCont.coreg.vol_image{kk}.fname);
 
 
 
@@ -269,7 +274,8 @@ for kk = 1:MRSCont.nDatasets
             % Save normalized fractional tissue volumes to MRSCont
             MRSCont.seg.tissue.fGM(kk,rr)  = fGM;
             MRSCont.seg.tissue.fWM(kk,rr)  = fWM;
-            MRSCont.seg.tissue.fCSF(kk,rr) = fCSF;
+            MRSCont.seg.tissue.fCSF(kk,rr) = fCSF;            
+            
         end
     end 
 end

--- a/seg/osp_extract_three_plane_image_seg.m
+++ b/seg/osp_extract_three_plane_image_seg.m
@@ -1,0 +1,45 @@
+% osp_extract_image_montage.m
+% Helge Zoellner, Johns Hopkins University 2021.
+%
+% USAGE:
+% [three_plane_image] = osp_extract_image_montage(ImageFile, MaskFile);
+%
+% DESCRIPTION:
+% Creates a SPM volume containing a voxel mask with the same dimensions
+% as the SPM volume containing a structural image. The voxel mask will be
+% created with the geometry information stored in the FID-A structure "in".
+% This routine works for the GE P data type.
+
+% INPUTS:
+% ImageFile   = Path to Image File (NifTI).
+% MaskFile    = Path to Mask Volume (NifTI).
+% VoxelIndex  = Voxel index for PRIAM
+%
+% OUTPUTS:
+% three_plane_img  = three plane image for plots and GUI.
+
+
+function [img_montage,size_vox_t] = osp_extract_three_plane_image_seg(ImageFile, MaskFile,GM,WM,CSF,voxel_ctr,T1_max);
+%%% 1. LOAD IMAGE AND MASK VOLUME %%%
+
+    Vimage=spm_vol(ImageFile);
+    Vmask=spm_vol(MaskFile);    
+    
+    vol_GM_mask  = spm_vol(GM);
+    vol_WM_mask  = spm_vol(WM);
+    vol_CSF_mask = spm_vol(CSF);
+
+    %%% 2. SET UP THREE PLANE IMAGE %%%
+    % Generate three plane image for the output
+    % Transform structural image and co-registered voxel mask from voxel to
+    % world space for output (MM: 180221)
+
+    img_t     = flipud(voxel2world_space(Vimage, voxel_ctr));
+    vox_t     = flipud(voxel2world_space(Vmask, voxel_ctr));
+    vox_t_GM  = flipud(voxel2world_space(vol_GM_mask, voxel_ctr));
+    vox_t_WM  = flipud(voxel2world_space(vol_WM_mask, voxel_ctr));
+    vox_t_CSF = flipud(voxel2world_space(vol_CSF_mask, voxel_ctr));
+    img_t = img_t/T1_max;
+    img_montage = [img_t+0.225*vox_t, img_t+0.3*vox_t_GM, img_t+0.225*vox_t_WM, img_t+0.4*vox_t_CSF];
+    size_vox_t = size(vox_t,2);
+end

--- a/settings/OspreySettings.m
+++ b/settings/OspreySettings.m
@@ -27,6 +27,7 @@ MRSCont.flags.isHERMES      = 0;
 MRSCont.flags.isHERCULES    = 0;
 MRSCont.flags.isPRIAM       = 0;
 MRSCont.flags.isMRSI        = 0;
+MRSCont.flags.addImages        = 0;
 MRSCont.opts.savePDF                = 0;
 MRSCont.opts.saveLCM                = 0;
 MRSCont.opts.savejMRUI              = 0;

--- a/utilities/OspreyAddImages.m
+++ b/utilities/OspreyAddImages.m
@@ -1,0 +1,167 @@
+function [MRSCont] = OspreyAddImages(MRSCont)
+%% [MRSCont] = OspreyAddImages(MRSCont)
+%   This function allows adds the three plane images into the container to
+%   make it transferable
+%
+%   USAGE:
+%       MRSCont = OspreyAddIamges(MRSCont);
+%
+%   INPUTS:
+%       MRSCont     = Osprey MRS data container.
+%
+%   OUTPUTS:
+%       MRSCont     = Osprey MRS data container.
+%
+%   AUTHOR:
+%       Dr. Helge Zollner (Johns Hopkins University, 2021-05-06)
+%       hzoelln2@jhmi.edu
+%   
+%   CREDITS:    
+%       This code is based on numerous functions from the FID-A toolbox by
+%       Dr. Jamie Near (McGill University)
+%       https://github.com/CIC-methods/FID-A
+%       Simpson et al., Magn Reson Med 77:23-33 (2017)
+%
+%   HISTORY:
+%       2021-07-23: First version of the code.
+
+
+%% Pack images from coregistration
+osp_CheckRunPreviousModule(MRSCont, 'OspreyCoreg')
+for kk = 1 : MRSCont.nDatasets
+    % Load T1 image, mask volume, T1 max value, and voxel center
+
+        if ~exist(MRSCont.coreg.vol_image{kk}.fname,'file')
+            gunzip([MRSCont.coreg.vol_image{kk}.fname, '.gz']);
+        end
+        if ~exist(MRSCont.coreg.vol_mask{kk}.fname,'file')
+            gunzip([MRSCont.coreg.vol_mask{kk}.fname, '.gz']);
+        end
+
+        %%% 3. SET UP THREE PLANE IMAGE %%%
+        if ~(isfield(MRSCont.flags,'isPRIAM') && (MRSCont.flags.isPRIAM == 1))
+            [MRSCont.coreg.three_plane_img{kk}] = osp_extract_three_plane_image(MRSCont.coreg.vol_image{kk}.fname, MRSCont.coreg.vol_mask{kk}.fname,MRSCont.coreg.voxel_ctr{kk},MRSCont.coreg.T1_max{kk});
+        else
+            [MRSCont.coreg.three_plane_img{kk}] = osp_extract_three_plane_image(MRSCont.coreg.vol_image{kk}.fname, MRSCont.coreg.vol_mask{kk}{VoxelIndex}.fname,MRSCont.coreg.voxel_ctr{kk}(:,:,VoxelIndex),MRSCont.coreg.T1_max{kk});
+        end
+
+        if ~MRSCont.flags.didSeg
+            if exist([MRSCont.coreg.vol_mask{kk}.fname, '.gz'],'file')
+                delete(MRSCont.coreg.vol_mask{kk}.fname);
+            end
+            if exist([MRSCont.coreg.vol_image{kk}.fname, '.gz'],'file')
+                delete(MRSCont.coreg.vol_image{kk}.fname);
+            end
+        end
+
+        %%% 4. SET UP FIGURE LAYOUT %%%
+        % Generate a new figure and keep the handle memorized
+
+        if ~MRSCont.flags.didSeg
+            if exist([MRSCont.coreg.vol_mask{kk}.fname, '.gz'],'file')
+                delete(MRSCont.coreg.vol_mask{kk}.fname);
+            end
+            if exist([MRSCont.coreg.vol_image{kk}.fname, '.gz'],'file')
+                delete(MRSCont.coreg.vol_image{kk}.fname);
+            end
+        end
+
+end
+
+%% Pack images from Segmentation
+osp_CheckRunPreviousModule(MRSCont, 'OspreySeg')
+for kk = 1 : MRSCont.nDatasets
+    [path_voxel,filename_voxel,~]   = fileparts(MRSCont.files{kk});
+
+    % For batch analysis, get the last two sub-folders (e.g. site and
+    % subject)
+    path_split          = regexp(path_voxel,filesep,'split');
+    if length(path_split) > 2
+        saveName = [path_split{end-1} '_' path_split{end} '_' filename_voxel];
+    end
+
+    segDestination = fullfile(MRSCont.outputFolder, 'SegMaps');
+    
+    %Loop over voxels (for DualVoxel)
+    if ~(isfield(MRSCont.flags,'isPRIAM') && (MRSCont.flags.isPRIAM == 1))
+        Voxels = 1;
+    else
+        Voxels = 2;
+    end
+    for rr = 1 : Voxels
+
+        if ~(isfield(MRSCont.flags,'isPRIAM') && (MRSCont.flags.isPRIAM == 1))
+            VoxelNum = '_Voxel_1';
+        else
+            VoxelNum = ['_Voxel_' num2str(rr)];
+        end
+
+        GM  = fullfile(segDestination, [saveName VoxelNum '_GM.nii']);
+        WM  = fullfile(segDestination, [saveName VoxelNum '_WM.nii']);
+        CSF = fullfile(segDestination, [saveName VoxelNum '_CSF.nii']);
+
+        if exist([GM '.gz'], 'file')
+            gunzip([GM '.gz']);
+            gunzip([WM '.gz']);
+            gunzip([CSF '.gz']);
+        else
+            if length(path_split) > 2
+                saveName = ['jobServer_' path_split{end} '_' filename_voxel];
+            end
+
+            segDestination = fullfile(MRSCont.outputFolder, 'SegMaps');
+
+            if ~(isfield(MRSCont.flags,'isPRIAM') && (MRSCont.flags.isPRIAM == 1))
+                VoxelNum = '_Voxel_1';
+            else
+                VoxelNum = ['_Voxel_' num2str(rr)];
+            end
+
+            GM  = fullfile(segDestination, [saveName VoxelNum '_GM.nii']);
+            WM  = fullfile(segDestination, [saveName VoxelNum '_WM.nii']);
+            CSF = fullfile(segDestination, [saveName VoxelNum '_CSF.nii']);
+            if exist([GM '.gz'], 'file')
+                gunzip([GM '.gz']);
+                gunzip([WM '.gz']);
+                gunzip([CSF '.gz']);
+            end
+        end
+
+        if ~exist(GM, 'file') % This is just for combability of older Osprey versions
+            GM  = fullfile(segDestination, [saveName '_GM.nii']);
+            WM  = fullfile(segDestination, [saveName '_WM.nii']);
+            CSF = fullfile(segDestination, [saveName '_CSF.nii']);
+        end
+
+        vol_GM_mask  = spm_vol(GM);
+        vol_WM_mask  = spm_vol(WM);
+        vol_CSF_mask = spm_vol(CSF);
+
+         [~, ~, T1ext]  = fileparts(MRSCont.coreg.vol_image{kk}.fname);
+        if strcmp(T1ext, '.gz') && ~exist(MRSCont.coreg.vol_image{kk}.fname,'file') 
+            gunzip(MRSCont.coreg.vol_image{kk}.fname)
+        end
+
+        %%% 3. SET UP THREE PLANE IMAGE %%%
+        if ~(isfield(MRSCont.flags,'isPRIAM') && (MRSCont.flags.isPRIAM == 1))
+            [MRSCont.seg.img_montage{kk},MRSCont.seg.size_vox_t(kk)] = osp_extract_three_plane_image_seg(MRSCont.coreg.vol_image{kk}.fname, MRSCont.coreg.vol_mask{kk}.fname,vol_GM_mask,vol_WM_mask,vol_CSF_mask,MRSCont.coreg.voxel_ctr{kk},MRSCont.coreg.T1_max{kk});
+        else
+            [MRSCont.seg.img_montage{kk},MRSCont.seg.size_vox_t(kk)] = osp_extract_three_plane_image_seg(MRSCont.coreg.vol_image{kk}.fname, MRSCont.coreg.vol_mask{kk}{rr}.fname,vol_GM_mask,vol_WM_mask,vol_CSF_mask,MRSCont.coreg.voxel_ctr{kk}(:,:,VoxelIndex),MRSCont.coreg.T1_max{kk});
+        end
+    end
+
+    if exist([GM, '.gz'],'file')
+        delete(GM);
+        delete(WM);
+        delete(CSF);
+    end
+    if exist([MRSCont.coreg.vol_image{kk}.fname, '.gz'],'file')
+        delete(MRSCont.coreg.vol_image{kk}.fname);
+    end
+    if exist([MRSCont.coreg.vol_mask{kk}.fname, '.gz'],'file')
+        delete(MRSCont.coreg.vol_mask{kk}.fname);
+    end
+end
+%% Update flags
+    MRSCont.flags.addImages = 1;
+end


### PR DESCRIPTION
- Added new functionalities which allow to share/copy the MRS container between different machines without losing the GUI functionalities. This flag (MRSCont.flags.addImages) is turned off by default to reduce the file size of the container.

- OspreyAddImages stores the three plane images that are required for the plot functions of coreg and seg into the container. This can be performed on already processed MRS containers.

- osp_extract_three_plane_image.m adds the images for the OspreCoreg plot into the container

- osp_extract_three_plane_image_seg.m adds the images for the OspreSeg plot into the container

- Further updates were added to the OspreyGUI function which automatically checks whether the container has been moved. The LogFile is then recreated on the new machine and the Coreg/Seg buttons are disabled. The coreg/seg tab is activated only for containers where the image files are available or the results are stored in the container. The same is the case for the external nii viewer.