### PR TITLE
BugFix accidental GUI crash

### DIFF
--- a/GUI/osp_onCoreg.m
+++ b/GUI/osp_onCoreg.m
@@ -26,6 +26,7 @@ function osp_onCoreg( ~, ~ ,gui)
 %       2020-01-16: First version of the code.
 %%% 1. DELETE OLD PLOTS %%%
     MRSCont = getappdata(gui.figure,'MRSCont'); % Get MRSCont from hidden container in gui class
+    set(gui.figure,'HandleVisibility','off');
     if isfield(gui.Results, 'coreg')
         if length(gui.layout.coregTab.Children) == 3
                 delete( gui.layout.coregTab.Children(1) );
@@ -45,6 +46,7 @@ function osp_onCoreg( ~, ~ ,gui)
     MRSCont = OspreyCoreg(MRSCont);    
     delete(gui.layout.dummy);
     setappdata(gui.figure,'MRSCont',MRSCont); % Write MRSCont into hidden container in gui class
+    set(gui.figure,'HandleVisibility','on');
 %%% 3. INITIALIZE OUTPUT WINDOW %%%    
     osp_iniCoregWindow(gui);
     gui.layout.b_coreg.Enable = 'off';

--- a/GUI/osp_onFit.m
+++ b/GUI/osp_onFit.m
@@ -26,6 +26,7 @@ function osp_onFit( ~, ~ ,gui)
 %       2020-01-16: First version of the code.
 %%% 1. DELETE OLD PLOTS %%%
     MRSCont = getappdata(gui.figure,'MRSCont'); % Get MRSCont from hidden container in gui class  
+    set(gui.figure,'HandleVisibility','off');
     gui.layout.tabs.Selection  = 3;
     [gui,MRSCont] = osp_processingWindow(gui,MRSCont);
 %%% 2. CALL OSPREYFIT %%%
@@ -95,6 +96,7 @@ function osp_onFit( ~, ~ ,gui)
         end        
     end
     setappdata(gui.figure,'MRSCont',MRSCont); % Write MRSCont into hidden container in gui class
+    set(gui.figure,'HandleVisibility','on');
 %%% 3. INITIALIZE OUTPUT WINDOW %%%    
     osp_iniFitWindow(gui);
     gui.layout.b_fit.Enable = 'off';

--- a/GUI/osp_onLoad.m
+++ b/GUI/osp_onLoad.m
@@ -26,6 +26,7 @@ function [gui] = osp_onLoad( ~, ~ ,gui)
 %       2020-01-16: First version of the code.
 %%% 1. INITIALIZE DATA %%%
     MRSCont = getappdata(gui.figure,'MRSCont'); % Get MRSCont from hidden container in gui class
+    set(gui.figure,'HandleVisibility','off');
     gui.layout.tabs.Selection  = 1;
     [gui,MRSCont] = osp_processingWindow(gui,MRSCont);
 %%% 2. CALL OSPREYLOAD %%%
@@ -58,6 +59,7 @@ function [gui] = osp_onLoad( ~, ~ ,gui)
     end
     gui.load.Names.Geom = fieldnames(MRSCont.raw{1,1}.geometry.size); %Get variables regarding voxel geometry
     setappdata(gui.figure,'MRSCont',MRSCont); % Write MRSCont into hidden container in gui class
+    set(gui.figure,'HandleVisibility','on');
 %%% 3. INITIALIZE OUTPUT WINDOW %%%     
     osp_iniLoadWindow(gui);
     gui.layout.b_load.Enable = 'off';

--- a/GUI/osp_onProc.m
+++ b/GUI/osp_onProc.m
@@ -26,6 +26,7 @@ function osp_onProc( ~, ~ ,gui)
 %       2020-01-16: First version of the code.
 %%% 1. INITIALIZE %%%
     MRSCont = getappdata(gui.figure,'MRSCont');  % Get MRSCont from hidden container in gui class 
+    set(gui.figure,'HandleVisibility','off');
     gui.layout.tabs.TabEnables{2} = 'on';
     gui.layout.tabs.Selection  = 2;
     [gui,MRSCont] = osp_processingWindow(gui,MRSCont);
@@ -36,6 +37,7 @@ function osp_onProc( ~, ~ ,gui)
     gui.process.Number = length(fieldnames(MRSCont.processed));
     gui.process.Names = fieldnames(MRSCont.processed);
     setappdata(gui.figure,'MRSCont',MRSCont); % Write MRSCont into hidden container in gui class
+    set(gui.figure,'HandleVisibility','on');
 %%% 3. INITIALIZE OUTPUT WINDOW %%%    
     osp_iniProcessWindow(gui);
     gui.layout.b_proc.Enable = 'off';

--- a/GUI/osp_onQuant.m
+++ b/GUI/osp_onQuant.m
@@ -26,6 +26,7 @@ function osp_onQuant( ~, ~ ,gui)
 %       2020-01-16: First version of the code.
 %%% 1. INITIALIZE %%%
     MRSCont = getappdata(gui.figure,'MRSCont'); % Get MRSCont from hidden container in gui class
+    set(gui.figure,'HandleVisibility','off');
     gui.layout.tabs.Selection  = 5;
     [gui,MRSCont] = osp_processingWindow(gui,MRSCont);
 %%% 2. CALL OSPREYQUANTIFY %%%    
@@ -73,5 +74,5 @@ function osp_onQuant( ~, ~ ,gui)
     set(gui.controls.pop_corrOvCorr,'callback',{@osp_pop_corrOvCorr_Call,gui});
     set(gui.controls.pop_whichcorrOvCorr,'callback',{@osp_pop_whichcorrOvCorr_Call,gui});
     gui.layout.b_quant.Enable = 'off';
-
+    set(gui.figure,'HandleVisibility','on');
 end % onQuant

--- a/GUI/osp_onSave.m
+++ b/GUI/osp_onSave.m
@@ -29,7 +29,8 @@ function osp_onSave( ~, ~,gui)
     % Determine output folder
     refProcessTime = tic;
     fprintf('Saving MRS container...\n');
-    MRSCont = getappdata(gui.figure,'MRSCont'); % Get MRSCont from hidden container in gui class    
+    MRSCont = getappdata(gui.figure,'MRSCont'); % Get MRSCont from hidden container in gui class  
+    set(gui.figure,'HandleVisibility','off');
     outputFolder    = MRSCont.outputFolder;
     outputFile      = MRSCont.outputFile;
     if ~exist(outputFolder,'dir')
@@ -40,5 +41,6 @@ function osp_onSave( ~, ~,gui)
     MRSCont.flags.isGUI = 1;
     fprintf('... done.\n');
     setappdata(gui.figure,'MRSCont',MRSCont); % Write MRSCont into hidden container in gui class
+    set(gui.figure,'HandleVisibility','on');
     toc(refProcessTime);
 end % onExit

--- a/GUI/osp_onSeg.m
+++ b/GUI/osp_onSeg.m
@@ -26,6 +26,7 @@ function osp_onSeg( ~, ~ ,gui)
 %       2020-01-16: First version of the code.
 %%% 1. DELETE OLD PLOTS %%%
     MRSCont = getappdata(gui.figure,'MRSCont'); % Get MRSCont from hidden container in gui class
+    set(gui.figure,'HandleVisibility','off');
     if isfield(gui.Results, 'coreg')
         if length(gui.layout.coregTab.Children) == 3
                 delete( gui.layout.coregTab.Children(1) );
@@ -45,6 +46,7 @@ function osp_onSeg( ~, ~ ,gui)
     MRSCont = OspreySeg(MRSCont);
     delete(gui.layout.dummy);
     setappdata(gui.figure,'MRSCont',MRSCont);   % Write MRSCont into hidden container in gui class 
+    set(gui.figure,'HandleVisibility','on');
 %%% 3. INITIALIZE OUTPUT WINDOW %%%    
     osp_iniCoregWindow(gui);       
     gui.layout.b_segm.Enable = 'off';


### PR DESCRIPTION
- Bug fix wrt reported issues with the GUI being closed during module calls. This was due to the changes of the handle visibility of the GUI which was supposed to overwrite old instance upon GUI call. The handle visibility is now changed dynamically on button click events to avoid crashes.