### PR TITLE
Add probabSpecReg

### DIFF
--- a/process/osp_processHERCULES.m
+++ b/process/osp_processHERCULES.m
@@ -82,13 +82,19 @@ for kk = 1:MRSCont.nDatasets
         % window is restricted to a certain frequency window.
         if ~MRSCont.flags.isPhantom
             switch MRSCont.opts.SpecReg %Pick spectral registration method (default is Robust Spectral Registration)
+                case 'ProbSpecReg'
+                    [raw_A, fs_A, phs_A, weights_A, driftPreA, driftPostA]   = op_probabSpecReg(raw_A, 'HERCULES', 0,refShift_ind_ini);
+                    [raw_B, fs_B, phs_B, weights_B, driftPreB, driftPostB]   = op_probabSpecReg(raw_B, 'HERCULES', 0, refShift_ind_ini);                  
+                    [raw_C, fs_C, phs_C, weights_C, driftPreC, driftPostC]   = op_probabSpecReg(raw_C, 'HERCULES', 0, refShift_ind_ini);                    
+                    [raw_D, fs_D, phs_D, weights_D, driftPreD, driftPostD]   = op_probabSpecReg(raw_D, 'HERCULES', 0, refShift_ind_ini);
+                    
                 case 'RobSpecReg'
                     [raw_A, fs_A, phs_A, weights_A, driftPreA, driftPostA]   = op_robustSpecReg(raw_A, 'HERCULES', 0,refShift_ind_ini);
                     [raw_B, fs_B, phs_B, weights_B, driftPreB, driftPostB]   = op_robustSpecReg(raw_B, 'HERCULES', 0, refShift_ind_ini);                  
                     [raw_C, fs_C, phs_C, weights_C, driftPreC, driftPostC]   = op_robustSpecReg(raw_C, 'HERCULES', 0, refShift_ind_ini);                    
                     [raw_D, fs_D, phs_D, weights_D, driftPreD, driftPostD]   = op_robustSpecReg(raw_D, 'HERCULES', 0, refShift_ind_ini);
                 case 'RestrSpecReg'
-                    [~, ~, ~, ~, commuteOrder] = osp_onOffClassifyHERMES(temp_rawA, temp_rawB, temp_rawC, temp_rawD);
+                    [~, ~, ~, ~, commuteOrder] = osp_onOffClassifyHERMES(raw_A, raw_B, raw_C, raw_D);
                     temp.raw_A = raw_A;
                     temp.raw_B = raw_B;
                     temp.raw_C = raw_C;

--- a/process/osp_processHERMES.m
+++ b/process/osp_processHERMES.m
@@ -82,6 +82,12 @@ for kk = 1:MRSCont.nDatasets
         % window is restricted to a certain frequency window.    
             if ~MRSCont.flags.isPhantom
                     switch MRSCont.opts.SpecReg %Pick spectral registration method (default is Robust Spectral Registration)
+                        case 'ProbSpecReg'
+                            [raw_A, fs_A, phs_A, weights_A, driftPreA, driftPostA]   = op_probabSpecReg(raw_A, 'HERCULES', 0,refShift_ind_ini);
+                            [raw_B, fs_B, phs_B, weights_B, driftPreB, driftPostB]   = op_probabSpecReg(raw_B, 'HERCULES', 0, refShift_ind_ini);                  
+                            [raw_C, fs_C, phs_C, weights_C, driftPreC, driftPostC]   = op_probabSpecReg(raw_C, 'HERCULES', 0, refShift_ind_ini);                    
+                            [raw_D, fs_D, phs_D, weights_D, driftPreD, driftPostD]   = op_probabSpecReg(raw_D, 'HERCULES', 0, refShift_ind_ini);
+                    
                         case 'RobSpecReg'
                             [raw_A, fs_A, phs_A, weights_A, driftPreA, driftPostA]   = op_robustSpecReg(raw_A, 'HERCULES', 0,refShift_ind_ini);
                             [raw_B, fs_B, phs_B, weights_B, driftPreB, driftPostB]   = op_robustSpecReg(raw_B, 'HERCULES', 0, refShift_ind_ini);                  

--- a/process/osp_processMEGA.m
+++ b/process/osp_processMEGA.m
@@ -68,6 +68,9 @@ for kk = 1:MRSCont.nDatasets
                     end
                 end
                 switch MRSCont.opts.SpecReg %Pick spectral registration method (default is Robust Spectral Registration)
+                    case 'ProbSpecReg'
+                        [raw, fs, phs, weights, driftPre, driftPost]   = op_probabSpecReg(raw, 'MEGA', 0,refShift_ind_ini);
+                  
                     case 'RobSpecReg'
                         [raw, fs, phs, weights, driftPre, driftPost]     = op_robustSpecReg(raw, 'MEGA', 0,refShift_ind_ini); % Align and average
                     case 'RestrSpecReg'
@@ -90,7 +93,7 @@ for kk = 1:MRSCont.nDatasets
             % Finally, apply some linebroadening. High-quality in-vitro
             % data may have linewidth lower than the simulated basis set
             % data.
-            raw = op_filter(raw, 6);
+            raw = op_filter(raw, 2);
                 switch MRSCont.opts.SpecReg %Pick spectral registration method (default is Robust Spectral Registration)
                     case 'none'
                         [raw, fs, phs, weights, driftPre, driftPost]     = op_SpecRegFreqRestrict(raw, 'MEGA', 0,refShift_ind_ini,1); % Align and average  
@@ -118,7 +121,7 @@ for kk = 1:MRSCont.nDatasets
                 % referencing steps are performed in the later stages of
                 % post-processing and modelling, but we want the prominent singlets
                 % to appear within 0.1 ppm of their expected in-vivo positions.
-                phantomShiftPPM = 0.15 * raw.txfrq*1e-6;
+                phantomShiftPPM = 0.2 * raw.txfrq*1e-6;
                 raw = op_freqshift(raw, -phantomShiftPPM);
                 % Finally, apply some linebroadening. High-quality in-vitro
                 % data may have linewidth lower than the simulated basis set
@@ -252,7 +255,7 @@ for kk = 1:MRSCont.nDatasets
         raw_B = op_freqshift(raw_B, -refShift_SubSpecAlign);
         % Fit a double-Lorentzian to the Cr-Cho area, and phase the spectrum
         % with the negative phase of that fit
-        [raw_A,~]       = op_phaseCrCho(raw_A, 1);
+        [raw_A,ph]       = op_phaseCrCho(raw_A, 1);
         % Align the sub-spectra to one another by minimizing the difference
         % between the common 'reporter' signals.
         
@@ -262,6 +265,7 @@ for kk = 1:MRSCont.nDatasets
             case 'L2Norm'
             [raw_A, raw_B]  = osp_editSubSpecAlign(raw_A, raw_B, target,MRSCont.opts.UnstableWater);
             otherwise
+            raw_B     = op_addphase(raw_B, -ph*180/pi, 0, raw_B.centerFreq, 1);     
                 
         end
         


### PR DESCRIPTION
Added a multiplexed, probabilistic approach for aligning HERMES/HERCULES and MEGA data (adapted from Mark Mikkelsen's Gannet implementation). This can be used as a valid option in case of VAPOR WS which introduces different phases to the transients.

This can be envoked by   opts.SpecReg                = 'ProbSpecReg'; in the job file.