### PR TITLE
automated ONOFF classifier

### DIFF
--- a/process/osp_onOffClassifyHERMES.m
+++ b/process/osp_onOffClassifyHERMES.m
@@ -92,18 +92,34 @@ for ll = 1:4
     
 end
 
-% Determine the sub-spectra indices belonging to each editing pattern
-idx_OFF_OFF = ~second.ON & ~first.ON;
-idx_ON_OFF  = second.ON & ~first.ON;
-idx_OFF_ON  = ~second.ON & first.ON;
-idx_ON_ON   = second.ON & first.ON;
+try
+    % Determine the sub-spectra indices belonging to each editing pattern
+    idx_OFF_OFF = ~second.ON & ~first.ON;
+    idx_ON_OFF  = second.ON & ~first.ON;
+    idx_OFF_ON  = ~second.ON & first.ON;
+    idx_ON_ON   = second.ON & first.ON;
 
-% Commute for output
-inputVars = {'inA', 'inB', 'inC', 'inD'};
-eval(['outA = ' inputVars{idx_OFF_OFF} ';']);
-eval(['outB = ' inputVars{idx_ON_OFF} ';']);
-eval(['outC = ' inputVars{idx_OFF_ON} ';']);
-eval(['outD = ' inputVars{idx_ON_ON} ';']);
+    % Commute for output
+    inputVars = {'inA', 'inB', 'inC', 'inD'};
+    eval(['outA = ' inputVars{idx_OFF_OFF} ';']);
+    eval(['outB = ' inputVars{idx_ON_OFF} ';']);
+    eval(['outC = ' inputVars{idx_OFF_ON} ';']);
+    eval(['outD = ' inputVars{idx_ON_ON} ';']);
+catch
+    disp('HERMES classifier does not recognize the subspectra. You can change the ordering in osp_onOFFClassifyHERMES.m');
+    % Determine the sub-spectra indices belonging to each editing pattern
+    idx_OFF_OFF = 2;
+    idx_ON_OFF  = 1;
+    idx_OFF_ON  = 3;
+    idx_ON_ON   = 4;
+
+    % Commute for output
+    inputVars = {'inA', 'inB', 'inC', 'inD'};
+    eval(['outA = ' inputVars{idx_OFF_OFF} ';']);
+    eval(['outB = ' inputVars{idx_ON_OFF} ';']);
+    eval(['outC = ' inputVars{idx_OFF_ON} ';']);
+    eval(['outD = ' inputVars{idx_ON_ON} ';']);
+end
 
 % Save commute order
 commuteOrder = [find(idx_OFF_OFF), find(idx_ON_OFF), find(idx_OFF_ON), find(idx_ON_ON)];

--- a/process/osp_onOffClassifyMEGA.m
+++ b/process/osp_onOffClassifyMEGA.m
@@ -149,7 +149,10 @@ switch target
             switchOrder = 0;
         end        
     otherwise
-        error('MEGA ON/OFF classifier does not recognize the input argument ''target''. Set to ''GABA'' or ''GSH''.');
+        disp('MEGA ON/OFF classifier does not recognize the input argument ''target''. We automatically assume no reordering. You can change that in osp_onOFFClassifyMEGA.m');
+         outA = inA;
+        outB = inB;
+        switchOrder = 0;
 end
 
 

--- a/process/osp_processHERMES.m
+++ b/process/osp_processHERMES.m
@@ -186,12 +186,10 @@ for kk = 1:MRSCont.nDatasets
             end
 
             % Apply Klose eddy current correction
-            if kk ~= 7
             [raw_A,~]                   = op_eccKlose(raw_A, raw_ref);
             [raw_B,~]                   = op_eccKlose(raw_B, raw_ref);
             [raw_C,~]                   = op_eccKlose(raw_C, raw_ref);
             [raw_D,raw_ref]             = op_eccKlose(raw_D, raw_ref);
-            end
 
             [raw_ref,~]                 = op_ppmref(raw_ref,4.6,4.8,4.68);  % Reference to water @ 4.68 ppm
             MRSCont.processed.ref{kk}   = raw_ref;                          % Save back to MRSCont container


### PR DESCRIPTION
Added an default ordering of the ONOFF spectra for MEGA and HERMES in case the automatic detection fails. This can be changed in the specific function.

It will most likely be replaced by an job file entry in the updated OspreyProcess function