### PR TITLE
Bug report Guoying

### DIFF
--- a/GUI/osp_iniFitWindow.m
+++ b/GUI/osp_iniFitWindow.m
@@ -210,7 +210,7 @@ for t = 1 : gui.fit.Number %Loop over fits
             waterFitRangeString = ['Fitting range: ' num2str(MRSCont.opts.fit.rangeWater(1)) ' to ' num2str(MRSCont.opts.fit.rangeWater(2)) ' ppm'];
             % Where are the metabolite names stored?
             if strcmp(gui.fit.Style, 'ref') || strcmp(gui.fit.Style, 'w')
-                basisSetNames = MRSCont.fit.resBasisSet.(gui.fit.Style).water.(['np_sw_' num2str(round(MRSCont.processed.A{1}.sz(1))) '_' num2str(round(MRSCont.processed.A{1}.spectralwidth))]).name;
+                basisSetNames = MRSCont.fit.resBasisSet.(gui.fit.Style).water.(['np_sw_' num2str(round(MRSCont.processed.(gui.fit.Style){1}.sz(1))) '_' num2str(round(MRSCont.processed.(gui.fit.Style){1}.spectralwidth))]).name;
             else if strcmp(gui.fit.Style, 'conc')
                     basisSetNames = MRSCont.fit.resBasisSet.(gui.fit.Style).(['np_sw_' num2str(round(MRSCont.processed.A{1}.sz(1))) '_' num2str(round(MRSCont.processed.A{1}.spectralwidth))]).name;
                 else if strcmp(gui.fit.Style, 'off')
@@ -288,7 +288,7 @@ for t = 1 : gui.fit.Number %Loop over fits
                         if MRSCont.flags.hasRef %Calculate Raw Water Scaled amplitudes
                             RawAmpl = RawAmpl ./ (MRSCont.fit.results.ref.fitParams{1,gui.controls.Selected}.ampl .* MRSCont.fit.scale{gui.controls.Selected});
                         else
-                            RawAmpl = RawAmpl ./ (MRSCont.fit.results.water.fitParams{1,gui.controls.Selected}.ampl .* MRSCont.fit.scale{gui.controls.Selected});
+                            RawAmpl = RawAmpl ./ (MRSCont.fit.results.w.fitParams{1,gui.controls.Selected}.ampl .* MRSCont.fit.scale{gui.controls.Selected});
                         end
                     case 'LCModel'
                 end

--- a/GUI/osp_onPrint.m
+++ b/GUI/osp_onPrint.m
@@ -281,13 +281,13 @@ function osp_onPrint( ~, ~ ,gui)
                     waterFitRangeString = ['Fitting range: ' num2str(MRSCont.opts.fit.rangeWater(1)) ' to ' num2str(MRSCont.opts.fit.rangeWater(2)) ' ppm'];
                     % Where are the metabolite names stored?
                     if strcmp(gui.fit.Style, 'ref') || strcmp(gui.fit.Style, 'w')
-                    basisSetNames = MRSCont.fit.resBasisSet.(gui.fit.Style).water.(['np_sw_' num2str(MRSCont.processed.A{gui.controls.Selected}.sz(1)) '_' num2str(MRSCont.processed.A{1}.spectralwidth)]).name;
+                    basisSetNames = MRSCont.fit.resBasisSet.(gui.fit.Style).water.(['np_sw_' num2str(round(MRSCont.processed.A{gui.controls.Selected}.sz(1))) '_' num2str(round(MRSCont.processed.A{1}.spectralwidth))]).name;
                 else if strcmp(gui.fit.Style, 'conc')
-                        basisSetNames = MRSCont.fit.resBasisSet.(gui.fit.Style).(['np_sw_' num2str(MRSCont.processed.A{gui.controls.Selected}.sz(1)) '_' num2str(MRSCont.processed.A{1}.spectralwidth)]).name;
+                        basisSetNames = MRSCont.fit.resBasisSet.(gui.fit.Style).(['np_sw_' num2str(round(MRSCont.processed.A{gui.controls.Selected}.sz(1))) '_' num2str(round(MRSCont.processed.A{1}.spectralwidth))]).name;
                     else if strcmp(gui.fit.Style, 'off')
-                            basisSetNames = MRSCont.fit.resBasisSet.(gui.fit.Style).(['np_sw_' num2str(MRSCont.processed.A{gui.controls.Selected}.sz(1)) '_' num2str(MRSCont.processed.A{1}.spectralwidth)]).name;
+                            basisSetNames = MRSCont.fit.resBasisSet.(gui.fit.Style).(['np_sw_' num2str(round(MRSCont.processed.A{gui.controls.Selected}.sz(1))) '_' num2str(round(MRSCont.processed.A{1}.spectralwidth))]).name;
                         else
-                            basisSetNames = MRSCont.fit.resBasisSet.(gui.fit.Style).(['np_sw_' num2str(MRSCont.processed.A{gui.controls.Selected}.sz(1)) '_' num2str(MRSCont.processed.A{1}.spectralwidth)]).name;
+                            basisSetNames = MRSCont.fit.resBasisSet.(gui.fit.Style).(['np_sw_' num2str(round(MRSCont.processed.A{gui.controls.Selected}.sz(1))) '_' num2str(round(MRSCont.processed.A{1}.spectralwidth))]).name;
                         end
                     end
                 end
@@ -457,7 +457,7 @@ function osp_onPrint( ~, ~ ,gui)
                                 if MRSCont.flags.hasRef %Calculate Raw Water Scaled amplitudes
                                     RawAmpl = RawAmpl ./ (MRSCont.fit.results.ref.fitParams{1,gui.controls.Selected}.ampl .* MRSCont.fit.scale{gui.controls.Selected});
                                 else
-                                    RawAmpl = RawAmpl ./ (MRSCont.fit.results.water.fitParams{1,gui.controls.Selected}.ampl .* MRSCont.fit.scale{gui.controls.Selected});
+                                    RawAmpl = RawAmpl ./ (MRSCont.fit.results.w.fitParams{1,gui.controls.Selected}.ampl .* MRSCont.fit.scale{gui.controls.Selected});
                                 end
                             case 'LCModel'
                         end

--- a/GUI/osp_updateFitWindow.m
+++ b/GUI/osp_updateFitWindow.m
@@ -79,13 +79,13 @@ function osp_updateFitWindow(gui)
                 waterFitRangeString = ['Fitting range: ' num2str(MRSCont.opts.fit.rangeWater(1)) ' to ' num2str(MRSCont.opts.fit.rangeWater(2)) ' ppm'];
                 % Where are the metabolite names stored?
                 if strcmp(gui.fit.Style, 'ref') || strcmp(gui.fit.Style, 'w')
-                    basisSetNames = MRSCont.fit.resBasisSet.(gui.fit.Style).water.(['np_sw_' num2str(MRSCont.processed.A{gui.controls.Selected}.sz(1)) '_' num2str(MRSCont.processed.A{gui.controls.Selected}.spectralwidth)]).name;
+                    basisSetNames = MRSCont.fit.resBasisSet.(gui.fit.Style).water.(['np_sw_' num2str(round(MRSCont.processed.A{gui.controls.Selected}.sz(1))) '_' num2str(round(MRSCont.processed.A{gui.controls.Selected}.spectralwidth))]).name;
                 else if strcmp(gui.fit.Style, 'conc')
-                        basisSetNames = MRSCont.fit.resBasisSet.(gui.fit.Style).(['np_sw_' num2str(MRSCont.processed.A{gui.controls.Selected}.sz(1)) '_' num2str(MRSCont.processed.A{gui.controls.Selected}.spectralwidth)]).name;
+                        basisSetNames = MRSCont.fit.resBasisSet.(gui.fit.Style).(['np_sw_' num2str(round(MRSCont.processed.A{gui.controls.Selected}.sz(1))) '_' num2str(round(MRSCont.processed.A{gui.controls.Selected}.spectralwidth))]).name;
                     else if strcmp(gui.fit.Style, 'off')
-                            basisSetNames = MRSCont.fit.resBasisSet.(gui.fit.Style).(['np_sw_' num2str(MRSCont.processed.A{gui.controls.Selected}.sz(1)) '_' num2str(MRSCont.processed.A{gui.controls.Selected}.spectralwidth)]).name;
+                            basisSetNames = MRSCont.fit.resBasisSet.(gui.fit.Style).(['np_sw_' num2str(round(MRSCont.processed.A{gui.controls.Selected}.sz(1))) '_' num2str(round(MRSCont.processed.A{gui.controls.Selected}.spectralwidth))]).name;
                         else
-                            basisSetNames = MRSCont.fit.resBasisSet.(gui.fit.Style).(['np_sw_' num2str(MRSCont.processed.A{gui.controls.Selected}.sz(1)) '_' num2str(MRSCont.processed.A{gui.controls.Selected}.spectralwidth)]).name;
+                            basisSetNames = MRSCont.fit.resBasisSet.(gui.fit.Style).(['np_sw_' num2str(round(MRSCont.processed.A{gui.controls.Selected}.sz(1))) '_' num2str(round(MRSCont.processed.A{gui.controls.Selected}.spectralwidth))]).name;
                         end
                     end
                 end

--- a/overview/OspreyOverview.m
+++ b/overview/OspreyOverview.m
@@ -237,12 +237,12 @@ if MRSCont.flags.didFit
                         fitRangePPM = MRSCont.opts.fit.rangeWater;
                         if Voxels < 2
                             dataToPlot  = MRSCont.processed.(dataPlotNames{sf}){kk};
-                            basisSet    = MRSCont.fit.resBasisSet.(FitNames{sf}).water.(['np_sw_' num2str(dataToPlot.sz(1)) '_' num2str(dataToPlot.spectralwidth)]);
+                            basisSet    = MRSCont.fit.resBasisSet.(FitNames{sf}).water.(['np_sw_' num2str(round(dataToPlot.sz(1))) '_' num2str(round(dataToPlot.spectralwidth))]);
                             % Get the fit parameters
                             fitParams   = MRSCont.fit.results.(FitNames{sf}).fitParams{kk};
                         else
                             dataToPlot  = op_takeVoxel(MRSCont.processed.(dataPlotNames{sf}){kk},rr);
-                            basisSet    = MRSCont.fit.resBasisSet{rr}.(FitNames{sf}).water.(['np_sw_' num2str(dataToPlot.sz(1)) '_' num2str(dataToPlot.spectralwidth)]);                            
+                            basisSet    = MRSCont.fit.resBasisSet{rr}.(FitNames{sf}).water.(['np_sw_' num2str(round(dataToPlot.sz(1))) '_' num2str(round(dataToPlot.spectralwidth))]);                            
                             % Get the fit parameters
                             fitParams   = MRSCont.fit.results{rr}.(FitNames{sf}).fitParams{kk};
                         end
@@ -266,12 +266,12 @@ if MRSCont.flags.didFit
                         fitRangePPM = MRSCont.opts.fit.range;
                         if Voxels < 2
                             dataToPlot  = MRSCont.processed.(dataPlotNames{sf}){kk};
-                            basisSet    = MRSCont.fit.resBasisSet.(FitNames{sf}).(['np_sw_' num2str(dataToPlot.sz(1)) '_' num2str(dataToPlot.spectralwidth)]);
+                            basisSet    = MRSCont.fit.resBasisSet.(FitNames{sf}).(['np_sw_' num2str(round(dataToPlot.sz(1))) '_' num2str(round(dataToPlot.spectralwidth))]);
                             fitParams   = MRSCont.fit.results.(FitNames{sf}).fitParams{kk};                            
                         else
                            dataToPlot  = op_takeVoxel(MRSCont.processed.(dataPlotNames{sf}){kk},rr);
                            fitParams   = MRSCont.fit.results{rr}.(FitNames{sf}).fitParams{kk}; 
-                           basisSet    = MRSCont.fit.resBasisSet{rr}.(FitNames{sf}).(['np_sw_' num2str(dataToPlot.sz(1)) '_' num2str(dataToPlot.spectralwidth)]);
+                           basisSet    = MRSCont.fit.resBasisSet{rr}.(FitNames{sf}).(['np_sw_' num2str(round(dataToPlot.sz(1))) '_' num2str(round(dataToPlot.spectralwidth))]);
                         end
                         % Pack up into structs to feed into the reconstruction functions
                         inputData.dataToFit                 = dataToPlot;

--- a/plot/osp_plotFit.m
+++ b/plot/osp_plotFit.m
@@ -179,16 +179,16 @@ switch fitMethod
 
             if strcmp(which_spec, 'ref') || strcmp(which_spec, 'w')
                 fitRangePPM = MRSCont.opts.fit.rangeWater;
-                basisSet    = MRSCont.fit.resBasisSet.(which_spec).water.(['np_sw_' num2str(dataToPlot.sz(1)) '_' num2str(dataToPlot.spectralwidth)]);
+                basisSet    = MRSCont.fit.resBasisSet.(which_spec).water.(['np_sw_' num2str(round(dataToPlot.sz(1))) '_' num2str(round(dataToPlot.spectralwidth))]);
             else if strcmp(which_spec, 'conc')
                     fitRangePPM = MRSCont.opts.fit.range;
-                    basisSet    = MRSCont.fit.resBasisSet.(which_spec).(['np_sw_' num2str(dataToPlot.sz(1)) '_' num2str(dataToPlot.spectralwidth)]);
+                    basisSet    = MRSCont.fit.resBasisSet.(which_spec).(['np_sw_' num2str(round(dataToPlot.sz(1))) '_' num2str(round(dataToPlot.spectralwidth))]);
                 else if strcmp(which_spec, 'off')
                         fitRangePPM = MRSCont.opts.fit.range;
-                        basisSet    = MRSCont.fit.resBasisSet.(which_spec).(['np_sw_' num2str(dataToPlot.sz(1)) '_' num2str(dataToPlot.spectralwidth)]);
+                        basisSet    = MRSCont.fit.resBasisSet.(which_spec).(['np_sw_' num2str(round(dataToPlot.sz(1))) '_' num2str(round(dataToPlot.spectralwidth))]);
                     else
                         fitRangePPM = MRSCont.opts.fit.range;
-                        basisSet    = MRSCont.fit.resBasisSet.(which_spec).(['np_sw_' num2str(dataToPlot.sz(1)) '_' num2str(dataToPlot.spectralwidth)]);
+                        basisSet    = MRSCont.fit.resBasisSet.(which_spec).(['np_sw_' num2str(round(dataToPlot.sz(1))) '_' num2str(round(dataToPlot.spectralwidth))]);
                     end
                 end
             end

--- a/plot/osp_plotModule.m
+++ b/plot/osp_plotModule.m
@@ -478,7 +478,7 @@ switch Module
                         if MRSCont.flags.hasRef %Calculate Raw Water Scaled amplitudes
                             RawAmpl = RawAmpl ./ (MRSCont.fit.results.ref.fitParams{1,kk}.ampl .* MRSCont.fit.scale{kk});
                         else
-                            RawAmpl = RawAmpl ./ (MRSCont.fit.results.water.fitParams{1,kk}.ampl .* MRSCont.fit.scale{kk});
+                            RawAmpl = RawAmpl ./ (MRSCont.fit.results.w.fitParams{1,kk}.ampl .* MRSCont.fit.scale{kk});
                         end
                     case 'LCModel'
                 end

--- a/process/OspreyProcess.m
+++ b/process/OspreyProcess.m
@@ -65,7 +65,7 @@ NoSubSpec = length(fieldnames(MRSCont.processed));
 for ss = 1 : NoSubSpec
     for kk = 1 : MRSCont.nDatasets
             temp_sz(1,kk)= MRSCont.processed.(SubSpecNames{ss}){1,kk}.sz(1);
-            temp_sz_sw{1,kk} = ['np_sw_' num2str(MRSCont.processed.(SubSpecNames{ss}){1,kk}.sz(1)) '_' num2str(MRSCont.processed.(SubSpecNames{ss}){1,kk}.spectralwidth)];   
+            temp_sz_sw{1,kk} = ['np_sw_' num2str(round(MRSCont.processed.(SubSpecNames{ss}){1,kk}.sz(1))) '_' num2str(round(MRSCont.processed.(SubSpecNames{ss}){1,kk}.spectralwidth))];   
     end
     [MRSCont.info.(SubSpecNames{ss}).unique_ndatapoint_spectralwidth,MRSCont.info.(SubSpecNames{ss}).unique_ndatapoint_spectralwidth_ind,~]  = unique(temp_sz_sw,'Stable');
     [MRSCont.info.(SubSpecNames{ss}).max_ndatapoint,MRSCont.info.(SubSpecNames{ss}).max_ndatapoint_ind] = max(temp_sz);
@@ -124,7 +124,7 @@ if ~MRSCont.flags.isPRIAM && ~MRSCont.flags.isMRSI
         QM = horzcat(MRSCont.QM.SNR.(subspec{1})',MRSCont.QM.FWHM.(subspec{1})',MRSCont.QM.FWHM.ref',MRSCont.QM.res_water_amp.(subspec{1})',MRSCont.QM.freqShift.(subspec{1})');
     end
     MRSCont.QM.tables = array2table(QM,'VariableNames',names);
-    writetable(MRSCont.QM.tables,[outputFolder '/QM_processed_spectra.csv']);
+    writetable(MRSCont.QM.tables,[outputFolder filesep 'QM_processed_spectra.csv']);
 end
 
 % Optional:  Create all pdf figures

--- a/quantify/OspreyQuantify.m
+++ b/quantify/OspreyQuantify.m
@@ -161,12 +161,16 @@ if strcmp(MRSCont.opts.fit.method, 'LCModel')
     for kk = 1:MRSCont.nDatasets
         if  ~iscell(MRSCont.fit.results) %Is SVS %Is SVS
             MRSCont.quantify.CRLB{kk}.(getResults{ll}) = MRSCont.fit.results.(getResults{ll}).fitParams{kk}.CRLB';
+            if qtfyH2O
             MRSCont.quantify.h2oarea{kk}.(getResults{ll}) = MRSCont.fit.results.(getResults{ll}).fitParams{kk}.h2oarea;
+            end
         else %Is DualVoxel
             MRSCont.quantify.CRLB{kk}.(getResults{ll})(:,1) = MRSCont.fit.results{1}.(getResults{ll}).fitParams{kk}.CRLB';
            MRSCont.quantify.CRLB{kk}.(getResults{ll})(:,2) = MRSCont.fit.results{2}.(getResults{ll}).fitParams{kk}.CRLB';
+           if qtfyH2O
            MRSCont.quantify.h2oarea{kk}.(getResults{ll})(:,1) = MRSCont.fit.results{1}.(getResults{ll}).fitParams{kk}.h2oarea;
            MRSCont.quantify.h2oarea{kk}.(getResults{ll})(:,2) = MRSCont.fit.results{2}.(getResults{ll}).fitParams{kk}.h2oarea;
+           end
         end        
     end
 end
@@ -331,7 +335,9 @@ end
 %Generate tables from LCModel specific outputs
 if strcmp(MRSCont.opts.fit.method, 'LCModel')
     [MRSCont] = osp_createTable(MRSCont,'CRLB', getResults);
-    [MRSCont] = osp_createTable(MRSCont,'h2oarea', getResults);
+    if qtfyH2O
+     [MRSCont] = osp_createTable(MRSCont,'h2oarea', getResults);
+    end
 end
 %% Clean up and save
 % Set exit flags


### PR DESCRIPTION
Issue: Resampled basis set is not automatically picked and Osprey crashes (struct allows for integers only)

Fix: Rounded numbers to avoid such issues

Additional: Fix related to a different number of points and spectral width for the metabolite and water data. This bug was undetected as we were mostly using the eddy current reference for quantification and highly standardized acquisition parameters

Thank you Guoying for reporting this issue