### PR TITLE
Bug fix un-edited data

### DIFF
--- a/load/OspreyLoad.m
+++ b/load/OspreyLoad.m
@@ -143,6 +143,39 @@ elseif MRSCont.flags.isMRSI && ~strcmp(MRSCont.datatype,'DATA')
     [MRSCont] = osp_MRSIRecon(MRSCont);
 end
 
+if MRSCont.flags.isUnEdited
+    for kk = 1:MRSCont.nDatasets
+        raw                         = MRSCont.raw{kk};                                          % Get the kk-th dataset
+        %%% MERGE MULTIPLE DIMENSIONS %%%
+        % If the dimensionality of the dataset isn't just along the
+        % 'averages' dimension, we resort the other dimensions into the
+        % 'averages' dimension here
+        if raw.dims.extras ~= 0
+            % Generate empty struct
+            temp = struct;
+            % Extract extras and add to the temporary struct
+            for pp = 1:raw.sz(raw.dims.extras)
+                extrasToAdd = op_takeextras(raw, pp);
+                temp = op_concatAverages(temp, extrasToAdd);
+            end
+            % Save back to MRSCont
+            raw = temp;
+            MRSCont.raw{kk} = raw;
+        elseif raw.dims.subSpecs ~= 0
+            % Generate empty struct
+            temp = struct;
+            % Extract subspecs and add to the temporary struct
+            for pp = 1:raw.sz(raw.dims.extras)
+                subspecsToAdd = op_takesubspec(raw, pp);
+                temp = op_concatAverages(temp, subspecsToAdd);
+            end
+            % Save back to MRSCont
+            raw = temp;
+            MRSCont.raw{kk} = raw;
+        end
+    end
+end
+
 %% If DualVoxel or MRSI we want to extract y-axis scaling
 % Creates y-axis range to align the process plots between datasets
 if MRSCont.flags.isPRIAM || MRSCont.flags.isMRSI

--- a/process/osp_processUnEdited.m
+++ b/process/osp_processUnEdited.m
@@ -46,36 +46,8 @@ for kk = 1:MRSCont.nDatasets
     if ~(MRSCont.flags.didProcess == 1 && MRSCont.flags.speedUp && isfield(MRSCont, 'processed') && (kk > length(MRSCont.processed.A)))  || ~strcmp(MRSCont.ver.Osp,MRSCont.ver.CheckOsp)
 
         %%% 1. GET RAW DATA %%%
-        raw                         = MRSCont.raw{kk};                                          % Get the kk-th dataset
-        
-        %%% 1A. MERGE MULTIPLE DIMENSIONS %%%
-        % If the dimensionality of the dataset isn't just along the
-        % 'averages' dimension, we resort the other dimensions into the
-        % 'averages' dimension here
-        if raw.dims.extras ~= 0
-            % Generate empty struct
-            temp = struct;
-            % Extract extras and add to the temporary struct
-            for pp = 1:raw.sz(raw.dims.extras)
-                extrasToAdd = op_takeextras(raw, pp);
-                temp = op_concatAverages(temp, extrasToAdd);
-            end
-            % Save back to MRSCont
-            raw = temp;
-            MRSCont.raw{kk} = raw;
-        elseif raw.dims.subSpecs ~= 0
-            % Generate empty struct
-            temp = struct;
-            % Extract subspecs and add to the temporary struct
-            for pp = 1:raw.sz(raw.dims.extras)
-                subspecsToAdd = op_takesubspec(raw, pp);
-                temp = op_concatAverages(temp, subspecsToAdd);
-            end
-            % Save back to MRSCont
-            raw = temp;
-            MRSCont.raw{kk} = raw;
-        end
-        
+        raw                         = MRSCont.raw{kk};                                          % Get the kk-th dataset        
+                
         %%% 1B. GET MM DATA %%% 
         if MRSCont.flags.hasMM
             raw_mm                         = MRSCont.raw_mm{kk};              % Get the kk-th dataset re_mm


### PR DESCRIPTION
Add support for un-edited data with multiple measurements (i.e. extra/subspec dimensions).

The merge of multiple dimensions was done in the process function and did change the raw entries in the prior implementation. Therefore, the GUI crashed when only OspreyLoad was called.

Moved the clean-up in the OspreyLoad function to fix this