### PR TITLE
[FEATURE REQUEST] - Single file external segmentation - HBCD

### DIFF
--- a/exampledata/ima/jobIMA.m
+++ b/exampledata/ima/jobIMA.m
@@ -37,7 +37,7 @@
 %           provided in the NIfTI format (*.nii or *.nii.gz).
 %           (OPTIONAL)
 %           Defined in cell array "files_seg" with 1 x 3 cell for each
-%           subject
+%           subject or 1 x 1 cell if a single 4D NIfTI is supplied.
 %
 %   Files in the formats
 %       - .7 (GE)
@@ -260,10 +260,12 @@ for kk = 1:length(subs)
         % (OPTIONAL)
         % Link to NIfTI (*.nii or *.nii.gz) files with segmentation results
         % Add supply gray matter, white matter, and CSF as 1 x 3 cell within a
-        % cell array
+        % cell array  or a single 4D file in the same order supplied as 1 x 1 cell;
 %         files_seg(counter)   = {{[sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c1' sess(ll).name '_T1w.nii.gz'],...
 %                                  [sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c2' sess(ll).name '_T1w.nii.gz'],...
 %                                  [sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c3' sess(ll).name '_T1w.nii.gz']}};
+
+%         files_seg(counter)   = {{[sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep '4D' sess(ll).name '_T1w.nii.gz']}};
 
     end
 end
@@ -304,13 +306,15 @@ end
 % (OPTIONAL)
 % Link to NIfTI (*.nii or *.nii.gz) files with segmentation results
 % Add supply gray matter, white matter, and CSF as 1 x 3 cell within a
-% cell array
+% cell array  or a single 4D file in the same order supplied as 1 x 1 cell;
 %         files_seg(counter)   = {{'/Volumes/MyProject/data/sub-01/anat/c1T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-01/anat/c2T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-01/anat/c3T1w.nii.gz'},...
 %                                   {'/Volumes/MyProject/data/sub-02/anat/c1T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-02/anat/c2T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-02/anat/c3T1w.nii.gz'}};
+%         files_seg(counter)   = {{'/Volumes/MyProject/data/sub-01/anat/4DT1w.nii.gz'},...
+%                                   {'/Volumes/MyProject/data/sub-02/anat/4DT1w.nii.gz'}};
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/exampledata/nifti-mrs/jobNIfTIMRS.m
+++ b/exampledata/nifti-mrs/jobNIfTIMRS.m
@@ -37,7 +37,7 @@
 %           provided in the NIfTI format (*.nii or *.nii.gz).
 %           (OPTIONAL)
 %           Defined in cell array "files_seg" with 1 x 3 cell for each
-%           subject
+%           subject or 1 x 1 cell if a single 4D NIfTI is supplied.
 %
 %   Files in the formats
 %       - .7 (GE)
@@ -247,10 +247,12 @@ for kk = 1:length(subs)
         % (OPTIONAL)
         % Link to NIfTI (*.nii or *.nii.gz) files with segmentation results
         % Add supply gray matter, white matter, and CSF as 1 x 3 cell within a
-        % cell array
+        % cell array  or a single 4D file in the same order supplied as 1 x 1 cell;
 %         files_seg(counter)   = {{[sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c1' sess(ll).name '_T1w.nii.gz'],...
 %                                  [sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c2' sess(ll).name '_T1w.nii.gz'],...
 %                                  [sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c3' sess(ll).name '_T1w.nii.gz']}};
+
+%         files_seg(counter)   = {{[sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep '4D' sess(ll).name '_T1w.nii.gz']}};
 
         counter             = counter + 1;
     end
@@ -292,13 +294,15 @@ end
 % (OPTIONAL)
 % Link to NIfTI (*.nii or *.nii.gz) files with segmentation results
 % Add supply gray matter, white matter, and CSF as 1 x 3 cell within a
-% cell array
+% cell array  or a single 4D file in the same order supplied as 1 x 1 cell;
 %         files_seg(counter)   = {{'/Volumes/MyProject/data/sub-01/anat/c1T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-01/anat/c2T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-01/anat/c3T1w.nii.gz'},...
 %                                   {'/Volumes/MyProject/data/sub-02/anat/c1T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-02/anat/c2T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-02/anat/c3T1w.nii.gz'}};
+%         files_seg(counter)   = {{'/Volumes/MyProject/data/sub-01/anat/4DT1w.nii.gz'},...
+%                                   {'/Volumes/MyProject/data/sub-02/anat/4DT1w.nii.gz'}};
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/exampledata/p/jobP.m
+++ b/exampledata/p/jobP.m
@@ -37,7 +37,7 @@
 %           provided in the NIfTI format (*.nii or *.nii.gz).
 %           (OPTIONAL)
 %           Defined in cell array "files_seg" with 1 x 3 cell for each
-%           subject
+%           subject or 1 x 1 cell if a single 4D NIfTI is supplied.
 %
 %   Files in the formats
 %       - .7 (GE)
@@ -245,10 +245,12 @@ for kk = 1:length(subs)
         % (OPTIONAL)
         % Link to NIfTI (*.nii or *.nii.gz) files with segmentation results
         % Add supply gray matter, white matter, and CSF as 1 x 3 cell within a
-        % cell array
+        % cell array  or a single 4D file in the same order supplied as 1 x 1 cell;
 %         files_seg(counter)   = {{[sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c1' sess(ll).name '_T1w.nii.gz'],...
 %                                  [sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c2' sess(ll).name '_T1w.nii.gz'],...
 %                                  [sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c3' sess(ll).name '_T1w.nii.gz']}};
+
+%         files_seg(counter)   = {{[sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep '4D' sess(ll).name '_T1w.nii.gz']}};
 
         counter             = counter + 1;
     end
@@ -289,13 +291,15 @@ end
 % (OPTIONAL)
 % Link to NIfTI (*.nii or *.nii.gz) files with segmentation results
 % Add supply gray matter, white matter, and CSF as 1 x 3 cell within a
-% cell array
+% cell array  or a single 4D file in the same order supplied as 1 x 1 cell;
 %         files_seg(counter)   = {{'/Volumes/MyProject/data/sub-01/anat/c1T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-01/anat/c2T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-01/anat/c3T1w.nii.gz'},...
 %                                   {'/Volumes/MyProject/data/sub-02/anat/c1T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-02/anat/c2T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-02/anat/c3T1w.nii.gz'}};
+%         files_seg(counter)   = {{'/Volumes/MyProject/data/sub-01/anat/4DT1w.nii.gz'},...
+%                                   {'/Volumes/MyProject/data/sub-02/anat/4DT1w.nii.gz'}};
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/exampledata/rda/jobRDA.m
+++ b/exampledata/rda/jobRDA.m
@@ -37,7 +37,7 @@
 %           provided in the NIfTI format (*.nii or *.nii.gz).
 %           (OPTIONAL)
 %           Defined in cell array "files_seg" with 1 x 3 cell for each
-%           subject
+%           subject or 1 x 1 cell if a single 4D NIfTI is supplied.
 %
 %   Files in the formats
 %       - .7 (GE)
@@ -247,10 +247,12 @@ for kk = 1:length(subs)
         % (OPTIONAL)
         % Link to NIfTI (*.nii or *.nii.gz) files with segmentation results
         % Add supply gray matter, white matter, and CSF as 1 x 3 cell within a
-        % cell array
+        % cell array  or a single 4D file in the same order supplied as 1 x 1 cell;
 %         files_seg(counter)   = {{[sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c1' sess(ll).name '_T1w.nii.gz'],...
 %                                  [sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c2' sess(ll).name '_T1w.nii.gz'],...
 %                                  [sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c3' sess(ll).name '_T1w.nii.gz']}};
+
+%         files_seg(counter)   = {{[sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep '4D' sess(ll).name '_T1w.nii.gz']}};
 
         counter             = counter + 1;
     end
@@ -292,13 +294,15 @@ end
 % (OPTIONAL)
 % Link to NIfTI (*.nii or *.nii.gz) files with segmentation results
 % Add supply gray matter, white matter, and CSF as 1 x 3 cell within a
-% cell array
+% cell array  or a single 4D file in the same order supplied as 1 x 1 cell;
 %         files_seg(counter)   = {{'/Volumes/MyProject/data/sub-01/anat/c1T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-01/anat/c2T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-01/anat/c3T1w.nii.gz'},...
 %                                   {'/Volumes/MyProject/data/sub-02/anat/c1T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-02/anat/c2T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-02/anat/c3T1w.nii.gz'}};
+%         files_seg(counter)   = {{'/Volumes/MyProject/data/sub-01/anat/4DT1w.nii.gz'},...
+%                                   {'/Volumes/MyProject/data/sub-02/anat/4DT1w.nii.gz'}};
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/exampledata/sdat/MEGA/jobSDAT_MEGA.m
+++ b/exampledata/sdat/MEGA/jobSDAT_MEGA.m
@@ -37,7 +37,7 @@
 %           provided in the NIfTI format (*.nii or *.nii.gz).
 %           (OPTIONAL)
 %           Defined in cell array "files_seg" with 1 x 3 cell for each
-%           subject
+%           subject or 1 x 1 cell if a single 4D NIfTI is supplied.
 %
 %   Files in the formats
 %       - .7 (GE)
@@ -260,10 +260,12 @@ for kk = 1:length(subs)
         % (OPTIONAL)
         % Link to NIfTI (*.nii or *.nii.gz) files with segmentation results
         % Add supply gray matter, white matter, and CSF as 1 x 3 cell within a
-        % cell array
+        % cell array  or a single 4D file in the same order supplied as 1 x 1 cell;
 %         files_seg(counter)   = {{[sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c1' sess(ll).name '_T1w.nii.gz'],...
 %                                  [sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c2' sess(ll).name '_T1w.nii.gz'],...
 %                                  [sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c3' sess(ll).name '_T1w.nii.gz']}};
+
+%         files_seg(counter)   = {{[sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep '4D' sess(ll).name '_T1w.nii.gz']}};
 
         counter             = counter + 1;
     end
@@ -305,13 +307,15 @@ end
 % (OPTIONAL)
 % Link to NIfTI (*.nii or *.nii.gz) files with segmentation results
 % Add supply gray matter, white matter, and CSF as 1 x 3 cell within a
-% cell array
+% cell array  or a single 4D file in the same order supplied as 1 x 1 cell;
 %         files_seg(counter)   = {{'/Volumes/MyProject/data/sub-01/anat/c1T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-01/anat/c2T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-01/anat/c3T1w.nii.gz'},...
 %                                   {'/Volumes/MyProject/data/sub-02/anat/c1T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-02/anat/c2T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-02/anat/c3T1w.nii.gz'}};
+%         files_seg(counter)   = {{'/Volumes/MyProject/data/sub-01/anat/4DT1w.nii.gz'},...
+%                                   {'/Volumes/MyProject/data/sub-02/anat/4DT1w.nii.gz'}};
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/exampledata/sdat/MEGA/jobSDAT_MEGA_Multidataset.m
+++ b/exampledata/sdat/MEGA/jobSDAT_MEGA_Multidataset.m
@@ -37,7 +37,7 @@
 %           provided in the NIfTI format (*.nii or *.nii.gz).
 %           (OPTIONAL)
 %           Defined in cell array "files_seg" with 1 x 3 cell for each
-%           subject
+%           subject or 1 x 1 cell if a single 4D NIfTI is supplied.
 %
 %   Files in the formats
 %       - .7 (GE)
@@ -263,10 +263,12 @@ for kk = 1:length(subs)
         % (OPTIONAL)
         % Link to NIfTI (*.nii or *.nii.gz) files with segmentation results
         % Add supply gray matter, white matter, and CSF as 1 x 3 cell within a
-        % cell array
+        % cell array  or a single 4D file in the same order supplied as 1 x 1 cell;
 %         files_seg(counter)   = {{[sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c1' sess(ll).name '_T1w.nii.gz'],...
 %                                  [sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c2' sess(ll).name '_T1w.nii.gz'],...
 %                                  [sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c3' sess(ll).name '_T1w.nii.gz']}};
+
+%         files_seg(counter)   = {{[sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep '4D' sess(ll).name '_T1w.nii.gz']}};
 
         counter             = counter + 1;
     end
@@ -314,13 +316,15 @@ end
 % (OPTIONAL)
 % Link to NIfTI (*.nii or *.nii.gz) files with segmentation results
 % Add supply gray matter, white matter, and CSF as 1 x 3 cell within a
-% cell array
+% cell array  or a single 4D file in the same order supplied as 1 x 1 cell;
 %         files_seg(counter)   = {{'/Volumes/MyProject/data/sub-01/anat/c1T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-01/anat/c2T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-01/anat/c3T1w.nii.gz'},...
 %                                   {'/Volumes/MyProject/data/sub-02/anat/c1T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-02/anat/c2T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-02/anat/c3T1w.nii.gz'}};
+%         files_seg(counter)   = {{'/Volumes/MyProject/data/sub-01/anat/4DT1w.nii.gz'},...
+%                                   {'/Volumes/MyProject/data/sub-02/anat/4DT1w.nii.gz'}};
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/exampledata/sdat/UnEdited/jobSDAT.m
+++ b/exampledata/sdat/UnEdited/jobSDAT.m
@@ -37,7 +37,7 @@
 %           provided in the NIfTI format (*.nii or *.nii.gz).
 %           (OPTIONAL)
 %           Defined in cell array "files_seg" with 1 x 3 cell for each
-%           subject
+%           subject or 1 x 1 cell if a single 4D NIfTI is supplied.
 %
 %   Files in the formats
 %       - .7 (GE)
@@ -246,10 +246,12 @@ for kk = 1:length(subs)
         % (OPTIONAL)
         % Link to NIfTI (*.nii or *.nii.gz) files with segmentation results
         % Add supply gray matter, white matter, and CSF as 1 x 3 cell within a
-        % cell array
+        % cell array  or a single 4D file in the same order supplied as 1 x 1 cell;
 %         files_seg(counter)   = {{[sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c1' sess(ll).name '_T1w.nii.gz'],...
 %                                  [sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c2' sess(ll).name '_T1w.nii.gz'],...
 %                                  [sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c3' sess(ll).name '_T1w.nii.gz']}};
+
+%         files_seg(counter)   = {{[sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep '4D' sess(ll).name '_T1w.nii.gz']}};
 
         counter             = counter + 1;
     end
@@ -291,14 +293,15 @@ end
 % (OPTIONAL)
 % Link to NIfTI (*.nii or *.nii.gz) files with segmentation results
 % Add supply gray matter, white matter, and CSF as 1 x 3 cell within a
-% cell array
+% cell array  or a single 4D file in the same order supplied as 1 x 1 cell;
 %         files_seg(counter)   = {{'/Volumes/MyProject/data/sub-01/anat/c1T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-01/anat/c2T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-01/anat/c3T1w.nii.gz'},...
 %                                   {'/Volumes/MyProject/data/sub-02/anat/c1T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-02/anat/c2T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-02/anat/c3T1w.nii.gz'}};
-
+%         files_seg(counter)   = {{'/Volumes/MyProject/data/sub-01/anat/4DT1w.nii.gz'},...
+%                                   {'/Volumes/MyProject/data/sub-02/anat/4DT1w.nii.gz'}};
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% 4. SPECIFY STAT FILE %%%

--- a/exampledata/sdat/UnEdited/jobSDAT_LCModel.m
+++ b/exampledata/sdat/UnEdited/jobSDAT_LCModel.m
@@ -37,7 +37,7 @@
 %           provided in the NIfTI format (*.nii or *.nii.gz).
 %           (OPTIONAL)
 %           Defined in cell array "files_seg" with 1 x 3 cell for each
-%           subject
+%           subject or 1 x 1 cell if a single 4D NIfTI is supplied.
 %
 %   Files in the formats
 %       - .7 (GE)
@@ -261,10 +261,12 @@ for kk = 1:length(subs)
         % (OPTIONAL)
         % Link to NIfTI (*.nii or *.nii.gz) files with segmentation results
         % Add supply gray matter, white matter, and CSF as 1 x 3 cell within a
-        % cell array
+        % cell array  or a single 4D file in the same order supplied as 1 x 1 cell;
 %         files_seg(counter)   = {{[sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c1' sess(ll).name '_T1w.nii.gz'],...
 %                                  [sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c2' sess(ll).name '_T1w.nii.gz'],...
 %                                  [sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c3' sess(ll).name '_T1w.nii.gz']}};
+
+%         files_seg(counter)   = {{[sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep '4D' sess(ll).name '_T1w.nii.gz']}};
 
         counter             = counter + 1;
     end
@@ -306,13 +308,15 @@ end
 % (OPTIONAL)
 % Link to NIfTI (*.nii or *.nii.gz) files with segmentation results
 % Add supply gray matter, white matter, and CSF as 1 x 3 cell within a
-% cell array
+% cell array  or a single 4D file in the same order supplied as 1 x 1 cell;
 %         files_seg(counter)   = {{'/Volumes/MyProject/data/sub-01/anat/c1T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-01/anat/c2T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-01/anat/c3T1w.nii.gz'},...
 %                                   {'/Volumes/MyProject/data/sub-02/anat/c1T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-02/anat/c2T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-02/anat/c3T1w.nii.gz'}};
+%         files_seg(counter)   = {{'/Volumes/MyProject/data/sub-01/anat/4DT1w.nii.gz'},...
+%                                   {'/Volumes/MyProject/data/sub-02/anat/4DT1w.nii.gz'}};
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/exampledata/twix/jobTwix.m
+++ b/exampledata/twix/jobTwix.m
@@ -37,7 +37,7 @@
 %           provided in the NIfTI format (*.nii or *.nii.gz).
 %           (OPTIONAL)
 %           Defined in cell array "files_seg" with 1 x 3 cell for each
-%           subject
+%           subject or 1 x 1 cell if a single 4D NIfTI is supplied.
 %
 %   Files in the formats
 %       - .7 (GE)
@@ -253,10 +253,12 @@ for kk = 1:length(subs)
         % (OPTIONAL)
         % Link to NIfTI (*.nii or *.nii.gz) files with segmentation results
         % Add supply gray matter, white matter, and CSF as 1 x 3 cell within a
-        % cell array
+        % cell array  or a single 4D file in the same order supplied as 1 x 1 cell;
 %         files_seg(counter)   = {{[sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c1' sess(ll).name '_T1w.nii.gz'],...
 %                                  [sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c2' sess(ll).name '_T1w.nii.gz'],...
 %                                  [sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep 'c3' sess(ll).name '_T1w.nii.gz']}};
+
+%         files_seg(counter)   = {{[sess(ll).folder filesep sess(ll).name filesep 'anat' filesep subs(kk).name filesep '4D' sess(ll).name '_T1w.nii.gz']}};
 
         counter             = counter + 1;
     end
@@ -298,13 +300,15 @@ end
 % (OPTIONAL)
 % Link to NIfTI (*.nii or *.nii.gz) files with segmentation results
 % Add supply gray matter, white matter, and CSF as 1 x 3 cell within a
-% cell array
+% cell array  or a single 4D file in the same order supplied as 1 x 1 cell;
 %         files_seg(counter)   = {{'/Volumes/MyProject/data/sub-01/anat/c1T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-01/anat/c2T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-01/anat/c3T1w.nii.gz'},...
 %                                   {'/Volumes/MyProject/data/sub-02/anat/c1T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-02/anat/c2T1w.nii.gz',...
 %                                  '/Volumes/MyProject/data/sub-02/anat/c3T1w.nii.gz'}};
+%         files_seg(counter)   = {{'/Volumes/MyProject/data/sub-01/anat/4DT1w.nii.gz'},...
+%                                   {'/Volumes/MyProject/data/sub-02/anat/4DT1w.nii.gz'}};
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
- Osprey accepts external tissue segmentation maps as a single file 4D NIfTI (the order of the tissue segmentation has to be changed by the user to accurately perform the segmentation)