### PR TITLE
HBCD changes -  [FEATURE REQUEST] - multiple functions - Helge Zöllner

### DIFF
--- a/fit/osp_fitInitialise.m
+++ b/fit/osp_fitInitialise.m
@@ -90,7 +90,7 @@ if ~(isfield(MRSCont.opts.fit,'basisSetFile') && ~isempty(MRSCont.opts.fit.basis
             case 'Philips'
                 MRSCont.opts.fit.basisSetFile        = which(['fit/basissets/' Bo '/philips/hercules-press/basis_philips_hercules-press.mat']);
             case 'GE'
-                MRSCont.opts.fit.basisSetFile        = which(['fit/basissets/' Bo '/philips/hercules-press/basis_philips_hercules-press.mat']);
+                MRSCont.opts.fit.basisSetFile        = which(['fit/basissets/' Bo '/ge/hercules-press/basis_ge_hercules-press.mat']);
             case 'Siemens'
                 MRSCont.opts.fit.basisSetFile        = which(['fit/basissets/' Bo '/siemens/hercules-press/basis_siemens_hercules-press.mat']);
         end

--- a/job/OspreyJob.m
+++ b/job/OspreyJob.m
@@ -55,7 +55,7 @@ switch ext
     case '.json'
         jobFileFormat = 'json';
     otherwise
-        error('Unrecognized job file datatype. Job files need to end in .CSV, .M or .JASON');
+        error('Unrecognized job file datatype. Job files need to end in .CSV, .M or .JSON');
 end
 
 
@@ -245,7 +245,7 @@ if strcmp(jobFileFormat,'json')
         files_nii = jobStruct.files_nii';
     end
     if isfield(jobStruct, 'files_seg')
-        files_seg = jobStruct.files_seg';
+        files_seg = {jobStruct.files_seg}';
     end
     if isfield(jobStruct, 'files_sense')
         files_sense = jobStruct.sense';
@@ -475,6 +475,13 @@ switch seqType
             fprintf('Fitting style was changed to Separate, because concatenated modeling is still under development.\n');
             MRSCont.opts.fit.style = 'Separate';
         end
+        if isfield(opts.fit, 'coMM3')
+            MRSCont.opts.fit.coMM3 = opts.fit.coMM3;
+            MRSCont.opts.fit.FWHMcoMM3 = opts.fit.FWHMcoMM3;
+        else
+            MRSCont.opts.fit.coMM3 = 'freeGauss';
+            MRSCont.opts.fit.FWHMcoMM3 = 14;
+        end
         if ~isfield(MRSCont.opts.fit, 'GAP')
             MRSCont.opts.fit.GAP.sum = [];
             MRSCont.opts.fit.GAP.diff1 = [];
@@ -503,6 +510,13 @@ switch seqType
         if strcmp(opts.fit.style, 'Concatenated')
             fprintf('Fitting style was changed to Separate, because concatenated modeling is still under development.\n');
             MRSCont.opts.fit.style = 'Separate';
+        end
+        if isfield(opts.fit, 'coMM3')
+            MRSCont.opts.fit.coMM3 = opts.fit.coMM3;
+            MRSCont.opts.fit.FWHMcoMM3 = opts.fit.FWHMcoMM3;
+        else
+            MRSCont.opts.fit.coMM3 = 'freeGauss';
+            MRSCont.opts.fit.FWHMcoMM3 = 14;
         end
         if ~isfield(MRSCont.opts.fit, 'GAP')
             MRSCont.opts.fit.GAP.sum = [];

--- a/libraries/FID-A/processingTools/op_get_Multispectra_LW.m
+++ b/libraries/FID-A/processingTools/op_get_Multispectra_LW.m
@@ -27,13 +27,13 @@ end
 zpfactor=8;
 if ~MM
     if in.flags.isUnEdited
-        SNRRange = {[1.8,2.2]};
+        SNRRange = {[2.9,3.1]};
     end
     if in.flags.isMEGA
-        SNRRange = {[1.8,2.2],[2.8,3.2],[2.8,3.2],[2.8,3.2]};
+        SNRRange = {[2.9,3.1],[2.9,3.1],[2.8,3.2],[2.9,3.1]};
     end
     if in.flags.isHERMES || in.flags.isHERCULES
-        SNRRange = {[1.8,2.2],[2.8,3.2],[2.8,3.2],[1.8,2.2],[2.8,3.2],[2.8,3.2],[2.8,3.2]};
+        SNRRange = {[2.9,3.1],[2.9,3.1],[2.9,3.1],[2.9,3.1],[2.8,3.2],[2.8,3.2],[2.9,3.1]};
     end
 else
     if in.flags.isUnEdited

--- a/libraries/FID-A/processingTools/op_get_Multispectra_SNR.m
+++ b/libraries/FID-A/processingTools/op_get_Multispectra_SNR.m
@@ -24,16 +24,16 @@ noiseppmmin=-2;
 
 if ~MM
     if in.flags.isUnEdited
-        SNRRange = {[1.8,2.2]};
-        QC_names = {'tNAA'};
+        SNRRange = {[2.9,3.1]};
+        QC_names = {'tCr'};
     end
     if in.flags.isMEGA
-        SNRRange = {[1.8,2.2],[2.8,3.2],[2.8,3.2],[2.8,3.2]};
-        QC_names = {'tNAA','tCr',in.target,'tCr'};
+        SNRRange = {[2.9,3.1],[2.9,3.1],[2.8,3.2],[2.9,3.1]};
+        QC_names = {'tCr','tCr',in.target,'tCr'};
     end
     if in.flags.isHERMES || in.flags.isHERCULES
-        SNRRange = {[1.8,2.2],[2.8,3.2],[2.8,3.2],[1.8,2.2],[2.8,3.2],[2.8,3.2],[2.8,3.2]};
-        QC_names = {'tNAA','tCr','tCr','tNAA',in.target{1},in.target{2},'tCr'};
+        SNRRange = {[2.9,3.1],[2.9,3.1],[2.9,3.1],[2.9,3.1],[2.8,3.2],[2.8,3.2],[2.9,3.1]};
+        QC_names = {'tCr','tCr','tCr','tCr',in.target{1},in.target{2},'tCr'};
     end
 else
     if in.flags.isUnEdited

--- a/plot/OspreyHTMLReport.m
+++ b/plot/OspreyHTMLReport.m
@@ -31,7 +31,15 @@ ppmmin = 0.2;
 ppmmax=4.2;
 
 outputFolder    = fullfile(MRSCont.outputFolder,'Reports');
-outputFigures   = fullfile(MRSCont.outputFolder,'Reports','reportFigures',['sub-' num2str(kk)]);
+split_subject_path = strsplit(fileparts(MRSCont.files{kk}),filesep);
+str_ind_sub = find(contains(split_subject_path,'sub'));
+if ~isempty(str_ind_sub)
+    sub_str = split_subject_path(str_ind_sub(1));
+    sub_str = sub_str{1};
+else
+    sub_str = ['sub-' num2str(kk)];
+end
+outputFigures   = fullfile(MRSCont.outputFolder,'Reports','reportFigures',sub_str);
 [foldername,filename,~]  = fileparts(MRSCont.files{kk});
 
 if ~exist(outputFolder,'dir')
@@ -106,7 +114,7 @@ if MRSCont.processed.metab{kk}.flags.isUnEdited
      box off;
     set(out,'PaperUnits','centimeters');
     set(out,'PaperPosition',[0 0 20 15]);
-    saveas(out,fullfile(outputFigures,['sub-' num2str(kk) '_Aligned_',which_spec]),'jpg');
+    saveas(out,fullfile(outputFigures,[sub_str '_Aligned_',which_spec]),'jpg');
     close(out);
 
     
@@ -160,7 +168,7 @@ if MRSCont.processed.metab{kk}.flags.isUnEdited
     box off;
     set(out,'PaperUnits','centimeters');
     set(out,'PaperPosition',[0 0 20 15]);
-    saveas(out,fullfile(outputFigures,['sub-' num2str(kk) '_Drift_',which_spec]),'jpg');
+    saveas(out,fullfile(outputFigures,[sub_str '_Drift_',which_spec]),'jpg');
     close(out);
 
     ProcSpecNames = {'A'};
@@ -197,7 +205,7 @@ if MRSCont.processed.metab{kk}.flags.isUnEdited
         box off;
         set(out,'PaperUnits','centimeters');
         set(out,'PaperPosition',[0 0 20 15]);
-        saveas(out,fullfile(outputFigures,['sub-' num2str(kk) '_' which_spec,'_',which_sub_spec]),'jpg');
+        saveas(out,fullfile(outputFigures,[sub_str '_' which_spec,'_',which_sub_spec]),'jpg');
         close(out);
     end
 end
@@ -302,7 +310,7 @@ if MRSCont.processed.metab{kk}.flags.isMEGA
      box off;
     set(out,'PaperUnits','centimeters');
     set(out,'PaperPosition',[0 0 20 15]);
-    saveas(out,fullfile(outputFigures,['sub-' num2str(kk) '_Aligned_',which_spec]),'jpg');
+    saveas(out,fullfile(outputFigures,[sub_str '_Aligned_',which_spec]),'jpg');
     close(out);
 
     
@@ -345,7 +353,7 @@ if MRSCont.processed.metab{kk}.flags.isMEGA
     box off;
     set(out,'PaperUnits','centimeters');
     set(out,'PaperPosition',[0 0 20 15]);
-    saveas(out,fullfile(outputFigures,['sub-' num2str(kk) '_Drift_',which_spec]),'jpg');
+    saveas(out,fullfile(outputFigures,[sub_str '_Drift_',which_spec]),'jpg');
     close(out);
 
     ProcSpecNames = {'A','diff1'};
@@ -398,7 +406,7 @@ if MRSCont.processed.metab{kk}.flags.isMEGA
         box off;
         set(out,'PaperUnits','centimeters');
         set(out,'PaperPosition',[0 0 20 15]);
-        saveas(out,fullfile(outputFigures,['sub-' num2str(kk) '_' which_spec '_' which_sub_spec]),'jpg');
+        saveas(out,fullfile(outputFigures,[sub_str '_' which_spec '_' which_sub_spec]),'jpg');
         close(out);
     end
 end
@@ -511,7 +519,7 @@ if MRSCont.processed.metab{kk}.flags.isHERMES || MRSCont.processed.metab{kk}.fla
      box off;
     set(out,'PaperUnits','centimeters');
     set(out,'PaperPosition',[0 0 20 15]);
-    saveas(out,fullfile(outputFigures,['sub-' num2str(kk) '_Aligned_',which_spec]),'jpg');
+    saveas(out,fullfile(outputFigures,[sub_str '_Aligned_',which_spec]),'jpg');
     close(out);
 
     
@@ -554,7 +562,7 @@ if MRSCont.processed.metab{kk}.flags.isHERMES || MRSCont.processed.metab{kk}.fla
     box off;
     set(out,'PaperUnits','centimeters');
     set(out,'PaperPosition',[0 0 20 15]);
-    saveas(out,fullfile(outputFigures,['sub-' num2str(kk) '_Drift_',which_spec]),'jpg');
+    saveas(out,fullfile(outputFigures,[sub_str '_Drift_',which_spec]),'jpg');
     close(out);
 
     ProcSpecNames = {'sum','diff1','diff2'};
@@ -607,7 +615,7 @@ if MRSCont.processed.metab{kk}.flags.isHERMES || MRSCont.processed.metab{kk}.fla
         box off;
         set(out,'PaperUnits','centimeters');
         set(out,'PaperPosition',[0 0 20 15]);
-        saveas(out,fullfile(outputFigures,['sub-' num2str(kk) '_' which_spec,'_',which_sub_spec]),'jpg');
+        saveas(out,fullfile(outputFigures,[sub_str '_' which_spec,'_',which_sub_spec]),'jpg');
         close(out);
     end
 end
@@ -638,7 +646,7 @@ if MRSCont.flags.hasRef
     box off;
     set(out,'PaperUnits','centimeters');
     set(out,'PaperPosition',[0 0 20 15]);
-    saveas(out,fullfile(outputFigures,['sub-' num2str(kk) '_' which_spec]),'jpg');
+    saveas(out,fullfile(outputFigures,[sub_str '_' which_spec]),'jpg');
     close(out);
 
 end
@@ -669,7 +677,7 @@ if MRSCont.flags.hasWater
     box off;
     set(out,'PaperUnits','centimeters');
     set(out,'PaperPosition',[0 0 20 15]);
-    saveas(out,fullfile(outputFigures,['sub-' num2str(kk) '_' which_spec]),'jpg');
+    saveas(out,fullfile(outputFigures,[sub_str '_' which_spec]),'jpg');
     close(out);
 
 end
@@ -806,7 +814,7 @@ for f = 1 : length(spec_names)
     hold off;
     set(out,'PaperUnits','centimeters');
     set(out,'PaperPosition',[0 0 20 15]);
-    saveas(out,fullfile(outputFigures,['sub-' num2str(kk) '_' which_spec '_' basisSet.names{1} '_model']),'jpg');
+    saveas(out,fullfile(outputFigures,[sub_str '_' which_spec '_' basisSet.names{1} '_model']),'jpg');
     close(out);
 end
 %% Coreg/Seg images export
@@ -820,7 +828,7 @@ if MRSCont.flags.didCoreg
     colormap(out.Children,'gray');
     set(out,'PaperUnits','centimeters');
     set(out,'PaperPosition',[0 0 18 6]);
-    saveas(out,fullfile(outputFigures,['sub-' num2str(kk) '_coreg_svs_space-scanner_mask']),'jpg');
+    saveas(out,fullfile(outputFigures,[sub_str '_coreg_svs_space-scanner_mask']),'jpg');
     close(out);
     close(temp);
 end
@@ -833,13 +841,13 @@ if MRSCont.flags.didSeg
     colormap(out.Children,'gray');
     set(out,'PaperUnits','centimeters');
     set(out,'PaperPosition',[0 0 18 6]);
-    saveas(out,fullfile(outputFigures,['sub-' num2str(kk) '_seg_svs_space-scanner_mask']),'jpg');
+    saveas(out,fullfile(outputFigures,[sub_str '_seg_svs_space-scanner_mask']),'jpg');
     close(out);
     close(temp);
 end
 %% Write report in HTML files
 %write an html report: 
-fid=fopen(fullfile(outputFolder,['sub-',num2str(kk),'-report.html']),'w+');
+fid=fopen(fullfile(outputFolder,[sub_str,'-report.html']),'w+');
 fprintf(fid,'<!DOCTYPE html>');
 fprintf(fid,'\n<html>');
 fprintf(fid,'\n<head>');
@@ -873,72 +881,167 @@ fprintf(fid,'\n</head>');
 fprintf(fid,'\n<body>');
 
 logoPath=which('osprey.png');
-fprintf(fid,'\n<img src= " %s " width="35" height="28">',logoPath);
-fprintf(fid,'\n<h1> Osprey Analysis Report</h1>');
-fprintf(fid,'\n<p>FILENAME: %s </p>',filename);
-fprintf(fid,'\n<p>DATE: %s </p>',date);
-fprintf(fid,'\n<p> </p>');
-fprintf(fid,'\n\n<h2>Results of spectral registration:</h2>');
+if ~isempty(logoPath)
+    fprintf(fid,'\n<img src= " %s " width="35" height="28"> <b> \tOsprey Analysis Report</b> ',logoPath);
+else
+    fprintf(fid,'\n<b> Osprey Analysis Report</b>');
+end
+fprintf(fid,'\n<p><b>DATE:</b> %s \t <b>FILENAME:</b> %s </p>',date,filename);
+fprintf(fid,'\n<h2>Summary:</h2>');
 fprintf(fid,'\n<div class="row">');
 fprintf(fid,'\n\t<div class="column3">');
-fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,['sub-' num2str(kk) '_Aligned_metab.jpg']));
-fprintf(fid,'\n\t</div>');
-fprintf(fid,'\n\t<div class="column3">');
-fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,['sub-' num2str(kk) '_Drift_metab.jpg']));
-fprintf(fid,'\n\t</div>');
-fprintf(fid,'\n</div>');
-fprintf(fid,'\n\n<p> </p>');
 
-fprintf(fid,'\n\n<h2>Averaged spectra:</h2>');
-fprintf(fid,'\n<p><b>signal-to-noise tNAA</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,1))); 
+fprintf(fid,'\n<p><b>signal-to-noise tCr</b> \t%5.2f',table2array(MRSCont.QM.tables(kk,1))); 
 if table2array(MRSCont.QM.tables(kk,2)) / MRSCont.processed.metab{kk}.txfrq*1e6 < 0.1 
-    fprintf(fid,'\n<p style="color:green;"><b>linewidth tNAA [ppm]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,2))/ MRSCont.processed.metab{kk}.txfrq*1e6);
+    fprintf(fid,'\n<p  style="color:green;"><b>linewidth tCr [Hz]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,2)));
 end
 if table2array(MRSCont.QM.tables(kk,2))/ MRSCont.processed.metab{kk}.txfrq*1e6 > 0.1 && table2array(MRSCont.QM.tables(kk,2)) / MRSCont.processed.metab{kk}.txfrq*1e6 < 0.15
-    fprintf(fid,'\n<p style="color:orange;"><b>linewidth tNAA [ppm]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,2))/ MRSCont.processed.metab{kk}.txfrq*1e6);
+    fprintf(fid,'\n<p style="color:orange;"><b>linewidth tCr [Hz]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,2)));
 end
 if table2array(MRSCont.QM.tables(kk,2))/ MRSCont.processed.metab{kk}.txfrq*1e6 > 0.15
-    fprintf(fid,'\n<p style="color:red;"><b>linewidth tNAA [ppm]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,2))/ MRSCont.processed.metab{kk}.txfrq*1e6);
+    fprintf(fid,'\n<p style="color:red;"><b>linewidth tCr [Hz]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,2)));
 end
 
 if MRSCont.flags.hasRef
-    if table2array(MRSCont.QM.tables(kk,2)) / MRSCont.processed.ref{kk}.txfrq*1e6 < 0.1 
-        fprintf(fid,'\n<p style="color:green;"><b>linewidth water [ppm]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,3))/ MRSCont.processed.ref{kk}.txfrq*1e6);
+    if table2array(MRSCont.QM.tables(kk,3)) / MRSCont.processed.ref{kk}.txfrq*1e6 < 0.1 
+        fprintf(fid,'\n<p style="color:green;"><b>linewidth water [Hz]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,3)));
     end
-    if table2array(MRSCont.QM.tables(kk,2))/ MRSCont.processed.ref{kk}.txfrq*1e6 > 0.1 && table2array(MRSCont.QM.tables(kk,3)) / MRSCont.processed.ref{kk}.txfrq*1e6 < 0.15
-        fprintf(fid,'\n<p style="color:orange;"><b>linewidth water [ppm]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,3))/ MRSCont.processed.ref{kk}.txfrq*1e6);
+    if table2array(MRSCont.QM.tables(kk,3))/ MRSCont.processed.ref{kk}.txfrq*1e6 > 0.1 && table2array(MRSCont.QM.tables(kk,3)) / MRSCont.processed.ref{kk}.txfrq*1e6 < 0.15
+        fprintf(fid,'\n<p style="color:orange;"><b>linewidth water [Hz]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,3))/ MRSCont.processed.ref{kk}.txfrq*1e6);
     end   
-    if table2array(MRSCont.QM.tables(kk,2))/ MRSCont.processed.ref{kk}.txfrq*1e6 > 0.15
-        fprintf(fid,'\n<p style="color:red;"><b>linewidth water [ppm]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,3))/ MRSCont.processed.ref{kk}.txfrq*1e6);
+    if table2array(MRSCont.QM.tables(kk,3))/ MRSCont.processed.ref{kk}.txfrq*1e6 > 0.15
+        fprintf(fid,'\n<p style="color:red;"><b>linewidth water [Hz]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,3)));
+    end
+end
+fprintf(fid,'\n\t</div>'); 
+fprintf(fid,'\n\t<div class="column3">');
+if MRSCont.processed.metab{kk}.flags.isUnEdited
+    fprintf(fid,'\n<p><b>Model Residual A [%%]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,6)));
+end
+if MRSCont.processed.metab{kk}.flags.isMEGA
+    fprintf(fid,'\n<p><b>Model Residual diff1 [%%]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,7)));
+    fprintf(fid,'\n<p><b>Model Residual A [%%]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,6)));
+end
+if MRSCont.processed.metab{kk}.flags.isHERMES || MRSCont.processed.metab{kk}.flags.isHERCULES
+    fprintf(fid,'\n<p><b>Model Residual diff1 [%%]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,7)));
+    fprintf(fid,'\n<p><b>Model Residual diff2 [%%]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,8)));
+    fprintf(fid,'\n<p><b>Model Residual sum [%%]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,6)));
+end
+fprintf(fid,'\n\t</div>');
+fprintf(fid,'\n</div>');
+fprintf(fid,'\n<div class="row">');
+if MRSCont.processed.metab{kk}.flags.isUnEdited
+    fprintf(fid,'\n\t<div class="column3">');
+    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_metab_A_model.jpg']));
+    fprintf(fid,'\n\t</div>');    
+end
+if MRSCont.processed.metab{kk}.flags.isMEGA
+    fprintf(fid,'\n\t<div class="column3">');
+    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_metab_diff1_model.jpg']));
+    fprintf(fid,'\n\t</div>');
+    fprintf(fid,'\n\t<div class="column3">');
+    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_metab_A_model.jpg']));
+    fprintf(fid,'\n\t</div>');
+end
+if MRSCont.processed.metab{kk}.flags.isHERMES || MRSCont.processed.metab{kk}.flags.isHERCULES
+    fprintf(fid,'\n\t<div class="column3">');
+    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_metab_diff1_model.jpg']));
+    fprintf(fid,'\n\t</div>');
+    fprintf(fid,'\n\t<div class="column3">');
+    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_metab_diff2_model.jpg']));
+    fprintf(fid,'\n\t</div>');
+    fprintf(fid,'\n\t<div class="column3">');
+    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_metab_sum_model.jpg']));
+    fprintf(fid,'\n\t</div>');
+end
+fprintf(fid,'\n</div>');
+if MRSCont.flags.hasRef || MRSCont.flags.hasWater
+    fprintf(fid,'\n<div class="row">');
+    if MRSCont.flags.hasRef 
+        fprintf(fid,'\n\t<div class="column3">');
+        fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_ref_A_model.jpg']));
+        fprintf(fid,'\n\t</div>');
+        if MRSCont.flags.hasWater
+            fprintf(fid,'\n\t<div class="column3">');
+            fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_w_A_model.jpg']));
+            fprintf(fid,'\n\t</div>');
+        end
+    
+    end
+if MRSCont.flags.didCoreg
+    fprintf(fid,'\n\t<div class="column3">');
+    if MRSCont.flags.didSeg
+        fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%"> \n\t\t <img src= " %s" style="width:100%%">',...
+            fullfile(outputFigures,[sub_str '_coreg_svs_space-scanner_mask.jpg']),...
+            fullfile(outputFigures,[sub_str '_seg_svs_space-scanner_mask.jpg']));
+    else
+        fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_coreg_svs_space-scanner_mask.jpg']));
+    end
+    fprintf(fid,'\n\t</div>');
+end
+fprintf(fid,'\n</div>');
+end
+fprintf(fid,'\n\n<p> </p>');
+fprintf(fid,'\n\n<h2>Results of spectral registration:</h2>');
+fprintf(fid,'\n<div class="row">');
+fprintf(fid,'\n\t<div class="column3">');
+fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_Aligned_metab.jpg']));
+fprintf(fid,'\n\t</div>');
+fprintf(fid,'\n\t<div class="column3">');
+fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_Drift_metab.jpg']));
+fprintf(fid,'\n\t</div>');
+fprintf(fid,'\n</div>');
+fprintf(fid,'\n\n<p> </p>');
+fprintf(fid,'\n\n<h2>Averaged spectra:</h2>');
+fprintf(fid,'\n<p><b>signal-to-noise tCr</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,1))); 
+if table2array(MRSCont.QM.tables(kk,2)) / MRSCont.processed.metab{kk}.txfrq*1e6 < 0.1 
+    fprintf(fid,'\n<p style="color:green;"><b>linewidth tCr [Hz]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,2)));
+end
+if table2array(MRSCont.QM.tables(kk,2))/ MRSCont.processed.metab{kk}.txfrq*1e6 > 0.1 && table2array(MRSCont.QM.tables(kk,2)) / MRSCont.processed.metab{kk}.txfrq*1e6 < 0.15
+    fprintf(fid,'\n<p style="color:orange;"><b>linewidth tCr [Hz]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,2)));
+end
+if table2array(MRSCont.QM.tables(kk,2))/ MRSCont.processed.metab{kk}.txfrq*1e6 > 0.15
+    fprintf(fid,'\n<p style="color:red;"><b>linewidth tCr [Hz]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,2)));
+end
+
+if MRSCont.flags.hasRef
+    if table2array(MRSCont.QM.tables(kk,3)) / MRSCont.processed.ref{kk}.txfrq*1e6 < 0.1 
+        fprintf(fid,'\n<p style="color:green;"><b>linewidth water [Hz]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,3)));
+    end
+    if table2array(MRSCont.QM.tables(kk,3))/ MRSCont.processed.ref{kk}.txfrq*1e6 > 0.1 && table2array(MRSCont.QM.tables(kk,3)) / MRSCont.processed.ref{kk}.txfrq*1e6 < 0.15
+        fprintf(fid,'\n<p style="color:orange;"><b>linewidth water [Hz]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,3)));
+    end   
+    if table2array(MRSCont.QM.tables(kk,3))/ MRSCont.processed.ref{kk}.txfrq*1e6 > 0.15
+        fprintf(fid,'\n<p style="color:red;"><b>linewidth water [Hz]</b> \t%5.2f </p>',table2array(MRSCont.QM.tables(kk,3)));
     end
 end
 if MRSCont.processed.metab{kk}.flags.isUnEdited
     fprintf(fid,'\n<div class="row">');
     fprintf(fid,'\n\t<div class="column3">');
-    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,['sub-' num2str(kk) '_metab_A.jpg']));
+    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_metab_A.jpg']));
     fprintf(fid,'\n\t</div>');
     fprintf(fid,'\n</div>');
 end
 if MRSCont.processed.metab{kk}.flags.isMEGA
     fprintf(fid,'\n<div class="row">');
     fprintf(fid,'\n\t<div class="column3">');
-    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,['sub-' num2str(kk) '_metab_diff1.jpg']));
+    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_metab_diff1.jpg']));
     fprintf(fid,'\n\t</div>');
     fprintf(fid,'\n\t<div class="column3">');
-    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,['sub-' num2str(kk) '_metab_A.jpg']));
+    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_metab_A.jpg']));
     fprintf(fid,'\n\t</div>');
     fprintf(fid,'\n</div>');
 end
 if MRSCont.processed.metab{kk}.flags.isHERMES || MRSCont.processed.metab{kk}.flags.isHERCULES
     fprintf(fid,'\n<div class="row">');
     fprintf(fid,'\n\t<div class="column3">');
-    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,['sub-' num2str(kk) '_metab_diff1.jpg']));
+    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_metab_diff1.jpg']));
     fprintf(fid,'\n\t</div>');
     fprintf(fid,'\n\t<div class="column3">');
-    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,['sub-' num2str(kk) '_metab_diff2.jpg']));
+    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_metab_diff2.jpg']));
     fprintf(fid,'\n\t</div>');
     fprintf(fid,'\n\t<div class="column3">');
-    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,['sub-' num2str(kk) '_metab_sum.jpg']));
+    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_metab_sum.jpg']));
     fprintf(fid,'\n\t</div>');
     fprintf(fid,'\n</div>');
 end
@@ -946,12 +1049,12 @@ if MRSCont.flags.hasRef || MRSCont.flags.hasWater
     fprintf(fid,'\n<div class="row">');
     if MRSCont.flags.hasRef
         fprintf(fid,'\n\t<div class="column3">');
-        fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,['sub-' num2str(kk) '_ref.jpg']));
+        fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_ref.jpg']));
         fprintf(fid,'\n\t</div>');
     end
     if MRSCont.flags.hasWater
         fprintf(fid,'\n\t<div class="column3">');
-        fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,['sub-' num2str(kk) '_w.jpg']));
+        fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_w.jpg']));
         fprintf(fid,'\n\t</div>');
     end
     fprintf(fid,'\n</div>');
@@ -973,26 +1076,26 @@ end
 fprintf(fid,'\n<div class="row">');
 if MRSCont.processed.metab{kk}.flags.isUnEdited
     fprintf(fid,'\n\t<div class="column3">');
-    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,['sub-' num2str(kk) '_metab_A_model.jpg']));
+    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_metab_A_model.jpg']));
     fprintf(fid,'\n\t</div>');    
 end
 if MRSCont.processed.metab{kk}.flags.isMEGA
     fprintf(fid,'\n\t<div class="column3">');
-    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,['sub-' num2str(kk) '_metab_diff1_model.jpg']));
+    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_metab_diff1_model.jpg']));
     fprintf(fid,'\n\t</div>');
     fprintf(fid,'\n\t<div class="column3">');
-    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,['sub-' num2str(kk) '_metab_A_model.jpg']));
+    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_metab_A_model.jpg']));
     fprintf(fid,'\n\t</div>');
 end
 if MRSCont.processed.metab{kk}.flags.isHERMES || MRSCont.processed.metab{kk}.flags.isHERCULES
     fprintf(fid,'\n\t<div class="column3">');
-    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,['sub-' num2str(kk) '_metab_diff1_model.jpg']));
+    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_metab_diff1_model.jpg']));
     fprintf(fid,'\n\t</div>');
     fprintf(fid,'\n\t<div class="column3">');
-    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,['sub-' num2str(kk) '_metab_diff2_model.jpg']));
+    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_metab_diff2_model.jpg']));
     fprintf(fid,'\n\t</div>');
     fprintf(fid,'\n\t<div class="column3">');
-    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,['sub-' num2str(kk) '_metab_sum_model.jpg']));
+    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_metab_sum_model.jpg']));
     fprintf(fid,'\n\t</div>');
 end
 fprintf(fid,'\n</div>');
@@ -1000,11 +1103,11 @@ if MRSCont.flags.hasRef || MRSCont.flags.hasWater
     fprintf(fid,'\n<div class="row">');
     if MRSCont.flags.hasRef 
         fprintf(fid,'\n\t<div class="column3">');
-        fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,['sub-' num2str(kk) '_ref_A_model.jpg']));
+        fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_ref_A_model.jpg']));
         fprintf(fid,'\n\t</div>');
         if MRSCont.flags.hasWater
             fprintf(fid,'\n\t<div class="column3">');
-            fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,['sub-' num2str(kk) '_w_A_model.jpg']));
+            fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_w_A_model.jpg']));
             fprintf(fid,'\n\t</div>');
         end
     
@@ -1016,12 +1119,12 @@ if MRSCont.flags.didCoreg
     fprintf(fid,'\n\n<h2>Coregistration & Segmentation:</h2>');
     fprintf(fid,'\n<div class="row">');
     fprintf(fid,'\n\t<div class="column3">');
-    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,['sub-' num2str(kk) '_coreg_svs_space-scanner_mask.jpg']));
+    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_coreg_svs_space-scanner_mask.jpg']));
     fprintf(fid,'\n\t</div>');
 end
 if MRSCont.flags.didSeg
     fprintf(fid,'\n\t<div class="column3">');
-    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,['sub-' num2str(kk) '_seg_svs_space-scanner_mask.jpg']));
+    fprintf(fid,'\n\t\t<img src= " %s" style="width:100%%">',fullfile(outputFigures,[sub_str '_seg_svs_space-scanner_mask.jpg']));
     fprintf(fid,'\n\t</div>');
 end
 fprintf(fid,'\n</div>');

--- a/process/OspreyProcess.m
+++ b/process/OspreyProcess.m
@@ -831,9 +831,9 @@ else
     fprintf(fileID,msg);
     error(msg);
 end
-names = {'NAA_SNR','NAA_FWHM','residual_water_ampl','freqShift'};
+names = {'Cr_SNR','Cr_FWHM','residual_water_ampl','freqShift'};
 if MRSCont.flags.hasRef
-    names = {'NAA_SNR','NAA_FWHM','water_FWHM','residual_water_ampl','freqShift'};
+    names = {'Cr_SNR','Cr_FWHM','water_FWHM','residual_water_ampl','freqShift'};
 end
 
 if ~MRSCont.flags.isPRIAM && ~MRSCont.flags.isMRSI
@@ -849,13 +849,13 @@ if ~MRSCont.flags.isPRIAM && ~MRSCont.flags.isMRSI
     for JJ = 1:length(names)
         switch names{JJ}
             case 'NAA_SNR'
-                MRSCont.QM.tables.Properties.CustomProperties.VariableLongNames{'NAA_SNR'} = 'Signal to noise ratio of NAA';
-                MRSCont.QM.tables.Properties.VariableDescriptions{'NAA_SNR'} = ['The maximum amplitude of the NAA peak divided by twice the standard deviation of the noise calculated from subspectrum ' name];
-                MRSCont.QM.tables.Properties.VariableUnits{'NAA_SNR'} = 'arbitrary';
+                MRSCont.QM.tables.Properties.CustomProperties.VariableLongNames{'Cr_SNR'} = 'Signal to noise ratio of creatine';
+                MRSCont.QM.tables.Properties.VariableDescriptions{'Cr_SNR'} = ['The maximum amplitude of the creatine peak divided by twice the standard deviation of the noise calculated from subspectrum ' name];
+                MRSCont.QM.tables.Properties.VariableUnits{'Cr_SNR'} = 'arbitrary';
             case 'NAA_FWHM'
-                MRSCont.QM.tables.Properties.CustomProperties.VariableLongNames{'NAA_FWHM'} = 'Full width at half maximum of NAA';
-                MRSCont.QM.tables.Properties.VariableDescriptions{'NAA_FWHM'} = ['The width of the NAA peak at half the maximum amplitude calculated as the average of the FWHM of the data and the FWHM of a lorentzian fit calculated from subspectrum ' name];
-                MRSCont.QM.tables.Properties.VariableUnits{'NAA_FWHM'} = 'Hz';
+                MRSCont.QM.tables.Properties.CustomProperties.VariableLongNames{'Cr_FWHM'} = 'Full width at half maximum of creatine';
+                MRSCont.QM.tables.Properties.VariableDescriptions{'Cr_FWHM'} = ['The width of the creatine peak at half the maximum amplitude calculated as the average of the FWHM of the data and the FWHM of a lorentzian fit calculated from subspectrum ' name];
+                MRSCont.QM.tables.Properties.VariableUnits{'Cr_FWHM'} = 'Hz';
             case 'water_FWHM'
                 MRSCont.QM.tables.Properties.CustomProperties.VariableLongNames{'water_FWHM'} = 'Full width at half maximum of reference water peak';
                 MRSCont.QM.tables.Properties.VariableDescriptions{'water_FWHM'} = 'The width of the water peak at half the maximum amplitude calculated as the average of the FWHM of the data and the FWHM of a lorentzian fit';

--- a/seg/OspreySeg.m
+++ b/seg/OspreySeg.m
@@ -157,8 +157,48 @@ for kk = 1:MRSCont.nDatasets(1)
             CSFvol = spm_vol(segFileCSF);
         else
            SEGvol  = spm_vol(segFile4D);
-        end
+           if size(SEGvol,1)>1 % 4D volume
+               TissueSegFile4D = 1;
+           else % It's a 3D atlas with different numbers (we treat it as AAL atlas)
+               TissueSegFile4D = 0;
+           end
+
         
+            if ~TissueSegFile4D
+                % Get tissue maps from AAL atlas
+                [GM,WM,CSF,AAL]=AAL_to_3TissueSeg(SEGvol);
+                [AALpath,AALfilename,AALext] = fileparts(SEGvol.fname);
+                %Store them in SPM12 standard
+                GMvol.fname    = fullfile(AALpath,['c1' AALfilename AALext ]);
+                GMvol.descrip  = ['GMmask based on AAL atlas'];
+                GMvol.dim      = SEGvol.dim;
+                GMvol.dt       = SEGvol.dt;
+                GMvol.mat      = SEGvol.mat;
+                GMvol          = spm_write_vol(GMvol, GM);
+                
+                WMvol.fname    = fullfile(AALpath,['c2' AALfilename AALext ]);
+                WMvol.descrip  = ['WMmask based on AAL atlas'];
+                WMvol.dim      = SEGvol.dim;
+                WMvol.dt       = SEGvol.dt;
+                WMvol.mat      = SEGvol.mat;
+                WMvol          = spm_write_vol(WMvol, WM);
+                
+                CSFvol.fname    = fullfile(AALpath,['c3' AALfilename AALext ]);
+                CSFvol.descrip  = ['CSFmask based on AAL atlas'];
+                CSFvol.dim      = SEGvol.dim;
+                CSFvol.dt       = SEGvol.dt;
+                CSFvol.mat      = SEGvol.mat;
+                CSFvol          = spm_write_vol(CSFvol, CSF);
+                
+                AALvol.fname    = fullfile(AALpath,['aal' AALfilename AALext ]);
+                AALvol.descrip  = ['AAL atlas without L-R difference'];
+                AALvol.dim      = SEGvol.dim;
+                AALvol.dt       = SEGvol.dt;
+                AALvol.mat      = SEGvol.mat;
+                AALvol          = spm_write_vol(AALvol, AAL);
+            end
+        end
+
         %Loop over voxels (for DualVoxel)
         if ~(isfield(MRSCont.flags,'isPRIAM') && (MRSCont.flags.isPRIAM == 1))
             Voxels = 1;
@@ -198,7 +238,7 @@ for kk = 1:MRSCont.nDatasets(1)
             vol_GMMask.dim      = vol_mask.dim;
             vol_GMMask.dt       = vol_mask.dt;
             vol_GMMask.mat      = vol_mask.mat;
-            if ~singleTissueSegFile
+            if ~singleTissueSegFile || ~TissueSegFile4D
                 GM_voxmask_vol      = GMvol.private.dat(:,:,:) .* vol_mask.private.dat(:,:,:);
             else
                 GM_voxmask_vol      = SEGvol(1).private.dat(:,:,:,1) .* vol_mask.private.dat(:,:,:);
@@ -211,7 +251,7 @@ for kk = 1:MRSCont.nDatasets(1)
             vol_WMMask.dim      = vol_mask.dim;
             vol_WMMask.dt       = vol_mask.dt;
             vol_WMMask.mat      = vol_mask.mat;
-            if ~singleTissueSegFile
+            if ~singleTissueSegFile || ~TissueSegFile4D
                 WM_voxmask_vol      = WMvol.private.dat(:,:,:) .* vol_mask.private.dat(:,:,:);
             else
                 WM_voxmask_vol      = SEGvol(2).private.dat(:,:,:,2) .* vol_mask.private.dat(:,:,:);
@@ -224,7 +264,7 @@ for kk = 1:MRSCont.nDatasets(1)
             vol_CSFMask.dim     = vol_mask.dim;
             vol_CSFMask.dt      = vol_mask.dt;
             vol_CSFMask.mat     = vol_mask.mat;
-            if ~singleTissueSegFile
+            if ~singleTissueSegFile || ~TissueSegFile4D
                 CSF_voxmask_vol     = CSFvol.private.dat(:,:,:) .* vol_mask.private.dat(:,:,:);
             else
                 CSF_voxmask_vol      = SEGvol(3).private.dat(:,:,:,3) .* vol_mask.private.dat(:,:,:);
@@ -459,4 +499,59 @@ spm_jobman('run',matlabbatch);
 end
 
 
+function [GM,WM,CSF,AAL]=AAL_to_3TissueSeg(vol_aseg_dseg)
+% This function is only working for a specific AAL atlas. You have to adapt
+% the lable numbers to make it work for your specific atlas.
 
+GM = zeros(vol_aseg_dseg.dim);
+WM = zeros(vol_aseg_dseg.dim);
+CSF = zeros(vol_aseg_dseg.dim);
+AAL = zeros(vol_aseg_dseg.dim);
+aseg_dseg = spm_read_vols(vol_aseg_dseg);
+
+% Sort AAL labels into gray matter, white matter, and CSF
+% Create white matter mask
+WM(aseg_dseg==2 | aseg_dseg == 41) = 1; %Cerebral-White-Matter 1
+WM(aseg_dseg == 16) = 1;% Brain-Stem 2
+
+% Create gray matter mask
+GM(aseg_dseg==3 | aseg_dseg == 42) = 1;% Cerebral-Cortex 3
+GM(aseg_dseg==8 | aseg_dseg == 47) = 1;% Cerebellum-Cortex 4
+GM(aseg_dseg==10 | aseg_dseg == 49) = 1;% Thalamus-Proper* 5
+GM(aseg_dseg==11 | aseg_dseg == 50) = 1;% Caudate 6
+GM(aseg_dseg==12 | aseg_dseg == 51) = 1;% Putamen 7
+GM(aseg_dseg==13 | aseg_dseg == 52) = 1;% Pallidum 8
+GM(aseg_dseg==17 | aseg_dseg == 53) = 1;% Hippocampus 9
+GM(aseg_dseg==18 | aseg_dseg == 54) = 1;% Amygdala 10
+GM(aseg_dseg==26 | aseg_dseg == 58) = 1;% Accumbens-area 11
+GM(aseg_dseg==27 | aseg_dseg == 59) = 1;% Substantia-Nigra 12
+GM(aseg_dseg==28 | aseg_dseg == 60) = 1;% VentralDC 13
+GM(aseg_dseg==172) = 1;% Vermis 14
+
+% Create csf mask
+CSF(aseg_dseg==4 | aseg_dseg == 43) = 1;%Lateral Ventricles 15
+CSF(aseg_dseg==14) = 1;% 3rd Ventricle 16
+CSF(aseg_dseg==15) = 1;% 4th Ventricle 17
+
+% Create a single aal volume
+AAL(aseg_dseg==2 | aseg_dseg == 41) = 1; %Cerebral-White-Matter
+AAL(aseg_dseg==16) = 2;% Brain-Stem
+
+AAL(aseg_dseg==3 | aseg_dseg == 42) = 3;% Cerebral-Cortex
+AAL(aseg_dseg==8 | aseg_dseg == 47) = 4;% Cerebellum-Cortex
+AAL(aseg_dseg==10 | aseg_dseg == 49) = 5;% Thalamus-Proper*
+AAL(aseg_dseg==11 | aseg_dseg == 50) = 6;% Caudate
+AAL(aseg_dseg==12 | aseg_dseg == 51) = 7;% Putamen
+AAL(aseg_dseg==13 | aseg_dseg == 52) = 8;% Pallidum
+AAL(aseg_dseg==17 | aseg_dseg == 53) = 9;% Hippocampus
+AAL(aseg_dseg==18 | aseg_dseg == 54) = 10;% Amygdala
+AAL(aseg_dseg==26 | aseg_dseg == 58) = 11;% Accumbens-area
+AAL(aseg_dseg==27 | aseg_dseg == 59) = 12;% Substantia-Nigra
+AAL(aseg_dseg==28 | aseg_dseg == 60) = 13;% VentralDC
+AAL(aseg_dseg==172) = 14;% Vermis
+
+AAL(aseg_dseg==4 | aseg_dseg == 43) = 15;%Lateral Ventricles
+AAL(aseg_dseg==14) = 16;% 3rd Ventricle
+AAL(aseg_dseg==15) = 17;% 4th Ventricle
+
+end

--- a/utilities/CompileOspreyStandalone.m
+++ b/utilities/CompileOspreyStandalone.m
@@ -18,6 +18,7 @@ function CompileOspreyStandalone(OutputDir,SPM12Dir,WidgetsDir,GUILayoutDir)
 %   Comment out the whole 2. GET SPMPATH AND TOOLBOXES sessuib in osp_Toolbox_Check.m
 % 
 %   In addtion you should remove the startup.m file from your Matlab folder as this interfers with the compilation and results in non-crashing errors in the compiled version.
+%   Make sure to run a clear all before runnning the script.
 % 
 %   Add SPM12 to your path and include all subfolders!
 % 
@@ -251,7 +252,6 @@ opts = compiler.build.StandaloneApplicationOptions(appFile,...
     'AutoDetectDataFiles','On',...
     'TreatInputsAsNumeric','Off',...
     'Verbose','On');
-
 compiler.build.standaloneApplication(opts);
 
 %% 4. GUI export

--- a/utilities/OspreyMinReport.m
+++ b/utilities/OspreyMinReport.m
@@ -158,10 +158,10 @@ fprintf(fid,'\n \n');
 fprintf(fid,'|4. Data quality|  | \n');
 fprintf(fid,'|--|--| \n');
 if MRSCont.flags.isUnEdited || MRSCont.flags.isMEGA
-    fprintf(fid,'|a. SNR (NAA), linewidth (NAA) [Hz] | SNR: %.0f +- %.0f, linewidth %.2f +- %.2f Hz| \n', round(mean(MRSCont.QM.SNR.metab(1,:,1))),round(std(MRSCont.QM.SNR.metab(1,:,1)),2),round(mean(MRSCont.QM.FWHM.metab(1,:,1)),2),round(std(MRSCont.QM.FWHM.metab(1,:,1)),2)); % Here we need something for cases without fitting was done
+    fprintf(fid,'|a. SNR (Cr), linewidth (Cr) [Hz] | SNR: %.0f +- %.0f, linewidth %.2f +- %.2f Hz| \n', round(mean(MRSCont.QM.SNR.metab(1,:,1))),round(std(MRSCont.QM.SNR.metab(1,:,1)),2),round(mean(MRSCont.QM.FWHM.metab(1,:,1)),2),round(std(MRSCont.QM.FWHM.metab(1,:,1)),2)); % Here we need something for cases without fitting was done
 end
 if MRSCont.flags.isHERMES || MRSCont.flags.isHERCULES
-    fprintf(fid,'|a. SNR (NAA), linewidth (NAA) [Hz] | SNR: %.0f +- %.0f, linewidth %.2f +- %.2f Hz| \n', round(mean(MRSCont.QM.SNR.metab(1,:,7))),round(std(MRSCont.QM.SNR.metab(1,:,7)),2),round(mean(MRSCont.QM.FWHM.metab(1,:,7)),2),round(std(MRSCont.QM.FWHM.metab(1,:,7)),2)); % Here we need something for cases without fitting was done
+    fprintf(fid,'|a. SNR (Cr), linewidth (Cr) [Hz] | SNR: %.0f +- %.0f, linewidth %.2f +- %.2f Hz| \n', round(mean(MRSCont.QM.SNR.metab(1,:,7))),round(std(MRSCont.QM.SNR.metab(1,:,7)),2),round(mean(MRSCont.QM.FWHM.metab(1,:,7)),2),round(std(MRSCont.QM.FWHM.metab(1,:,7)),2)); % Here we need something for cases without fitting was done
 end
 fprintf(fid,'|b. Data exclusion criteria | %s| \n', 'None');
 if MRSCont.flags.isUnEdited


### PR DESCRIPTION
This commit includes numerous changes needed for the HBCD processing. See details below:

- osp_fitInitialise.m had a wrong path for the GE HERCULES basis set

- Fixed typo and wrong setup of the cell array for external segmentation files when .json files where used in OspreyJob.m

- Changed the reference/reporter signal for the linewidth and SNR to creatine for all sequences with changes in op_get_Mutlispectra_LW,m, op_get_Multispectra_SNR.m, OspreyHTMLReport.m, OspreyMinReport.m, and OspreyProcess.m

- Fixed a bug related to the linewidth calculation of creatine for HERMES/HERCULES data related to the included frequency range for the simple FWHM calculation

- Added a quick summary to the HTML report showing quality measures (LW, SNR, fit residual), all fits, and localization + segmentation (if available)

- Added segmentation based on anatomical labels. This works for HBCD atlas only