### PR TITLE
HBCD - external segmentation not finished case - Erik Lee

### DIFF
--- a/utilities/RunOspreyJob.m
+++ b/utilities/RunOspreyJob.m
@@ -35,7 +35,19 @@ function [MRSCont] = RunOspreyJob(jobFilePath)
 
     if ~isempty(MRSCont.files_nii)
         MRSCont = OspreyCoreg(MRSCont);
-        MRSCont = OspreySeg(MRSCont);
+        if ~isempty(MRSCont.files_seg)
+            seg = [num2str(~isempty(MRSCont.files_seg)) num2str(exist(MRSCont.files_seg{1}{1},'file'))];
+        else
+            seg = '00';
+        end
+        switch seg
+            case '00' %Do normal segmentation (No files_seg)
+                MRSCont = OspreySeg(MRSCont);
+            case '11' %files_seg are defined and finished.
+                MRSCont = OspreySeg(MRSCont);
+            otherwise % (10) files_seg are defined, but not finished yet. (Do nothing)
+        end
+        
     end
 
     MRSCont = OspreyQuantify(MRSCont);


### PR DESCRIPTION
Added a decision tree for the OspreySeg call in the RunOspreyJob function. In case a path to the external segmentation is supplied, but the file doesn't exist yet the OspreySeg will be skipped. This script is used in the compiled Osprey version.