### PR TITLE
[BUG FIX] - Osprey GUI crash - Model/Coreg button - Lewis Crawford

### DIFF
--- a/GUI/osp_onCoreg.m
+++ b/GUI/osp_onCoreg.m
@@ -40,6 +40,7 @@ function osp_onCoreg( ~, ~ ,gui)
             end
         end
     end
+    set(gui.layout.tabs,'SelectionChangedFcn','');
     gui.layout.tabs.Selection  = 4;
 %%% 2. CALL OSPREYCOREG %%%    
     [gui,MRSCont] = osp_processingWindow(gui,MRSCont);  
@@ -51,4 +52,5 @@ function osp_onCoreg( ~, ~ ,gui)
     osp_iniCoregWindow(gui);
     gui.layout.b_coreg.Enable = 'off';
     gui.layout.b_segm.Enable = 'on';
+    set(gui.layout.tabs,'SelectionChangedFcn',{@osp_SelectionChangedFcn,gui});
 end % onCoreg

--- a/GUI/osp_onFit.m
+++ b/GUI/osp_onFit.m
@@ -27,6 +27,8 @@ function osp_onFit( ~, ~ ,gui)
 %%% 1. DELETE OLD PLOTS %%%
     MRSCont = getappdata(gui.figure,'MRSCont'); % Get MRSCont from hidden container in gui class  
     set(gui.figure,'HandleVisibility','off');
+    set(gui.layout.tabs,'SelectionChangedFcn','');
+    set(gui.layout.fitTab, 'SelectionChangedFcn','');
     gui.layout.tabs.Selection  = 3;
     [gui,MRSCont] = osp_processingWindow(gui,MRSCont);
 %%% 2. CALL OSPREYFIT %%%
@@ -101,4 +103,6 @@ function osp_onFit( ~, ~ ,gui)
     osp_iniFitWindow(gui);
     gui.layout.b_fit.Enable = 'off';
     gui.layout.b_quant.Enable = 'on';
+    set(gui.layout.tabs,'SelectionChangedFcn',{@osp_SelectionChangedFcn,gui});
+    set(gui.layout.fitTab, 'SelectionChangedFcn',{@osp_FitTabChangeFcn,gui});
 end % onFit

--- a/GUI/osp_onLoad.m
+++ b/GUI/osp_onLoad.m
@@ -27,6 +27,7 @@ function [gui] = osp_onLoad( ~, ~ ,gui)
 %%% 1. INITIALIZE DATA %%%
     MRSCont = getappdata(gui.figure,'MRSCont'); % Get MRSCont from hidden container in gui class
     set(gui.figure,'HandleVisibility','off');
+    set(gui.layout.tabs,'SelectionChangedFcn','');
     gui.layout.tabs.Selection  = 1;
     [gui,MRSCont] = osp_processingWindow(gui,MRSCont);
 %%% 2. CALL OSPREYLOAD %%%
@@ -68,5 +69,5 @@ function [gui] = osp_onLoad( ~, ~ ,gui)
         gui.layout.b_coreg.Enable = 'on';
     end
     gui.layout.ListBox.Enable = 'on';
-
+    set(gui.layout.tabs,'SelectionChangedFcn',{@osp_SelectionChangedFcn,gui});
 end % onLoad

--- a/GUI/osp_onProc.m
+++ b/GUI/osp_onProc.m
@@ -27,6 +27,7 @@ function osp_onProc( ~, ~ ,gui)
 %%% 1. INITIALIZE %%%
     MRSCont = getappdata(gui.figure,'MRSCont');  % Get MRSCont from hidden container in gui class 
     set(gui.figure,'HandleVisibility','off');
+    set(gui.layout.tabs,'SelectionChangedFcn','');
     gui.layout.tabs.TabEnables{2} = 'on';
     gui.layout.tabs.Selection  = 2;
     [gui,MRSCont] = osp_processingWindow(gui,MRSCont);
@@ -42,4 +43,5 @@ function osp_onProc( ~, ~ ,gui)
     osp_iniProcessWindow(gui);
     gui.layout.b_proc.Enable = 'off';
     gui.layout.b_fit.Enable = 'on';
+    set(gui.layout.tabs,'SelectionChangedFcn',{@osp_SelectionChangedFcn,gui});
 end % onProc

--- a/GUI/osp_onQuant.m
+++ b/GUI/osp_onQuant.m
@@ -27,6 +27,8 @@ function osp_onQuant( ~, ~ ,gui)
 %%% 1. INITIALIZE %%%
     MRSCont = getappdata(gui.figure,'MRSCont'); % Get MRSCont from hidden container in gui class
     set(gui.figure,'HandleVisibility','off');
+    set(gui.layout.tabs,'SelectionChangedFcn','');
+    set(gui.layout.quantifyTab, 'SelectionChangedFcn','');
     gui.layout.tabs.Selection  = 5;
     [gui,MRSCont] = osp_processingWindow(gui,MRSCont);
 %%% 2. CALL OSPREYQUANTIFY %%%    
@@ -75,4 +77,6 @@ function osp_onQuant( ~, ~ ,gui)
     set(gui.controls.pop_whichcorrOvCorr,'callback',{@osp_pop_whichcorrOvCorr_Call,gui});
     gui.layout.b_quant.Enable = 'off';
     set(gui.figure,'HandleVisibility','on');
+    set(gui.layout.tabs,'SelectionChangedFcn',{@osp_SelectionChangedFcn,gui});
+    set(gui.layout.quantifyTab, 'SelectionChangedFcn',{@osp_QuantTabChangeFcn,gui});
 end % onQuant

--- a/GUI/osp_onSeg.m
+++ b/GUI/osp_onSeg.m
@@ -40,6 +40,7 @@ function osp_onSeg( ~, ~ ,gui)
             end
         end
     end
+    set(gui.layout.tabs,'SelectionChangedFcn','');
     gui.layout.tabs.Selection  = 4;
     [gui,MRSCont] = osp_processingWindow(gui,MRSCont);
 %%% 2. CALL OSPREYSEG %%%    
@@ -61,4 +62,5 @@ function osp_onSeg( ~, ~ ,gui)
         gui.pop_distrOvQuantControls.String = gui.quant.Names.Quants;
         gui.pop_corrOvQuantControls.String = gui.quant.Names.Quants;
     end
+    set(gui.layout.tabs,'SelectionChangedFcn',{@osp_SelectionChangedFcn,gui});
 end % onSeg


### PR DESCRIPTION
Fixes issues related to the  GUI crash report on MRSHub (https://forum.mrshub.org/t/error-launching-model-data-and-coregister-in-osprey-gui/859/3).

The crash is potentially caused by the pause on error function in MATLAB, as there were some 'yellow' messages after clicking the model and coreg buttons. Those severe errors which were automatically fixed by MATLAB. However, those would still trigger a pause on error if this options is turned on. This is fixed now.

Thanks for reporting Lewis Crawford