### PR TITLE
BUG FIX - MM3co scaling - fit functions - Kathleen Hupfeld

### DIFF
--- a/fit/osp_fitHERCULES.m
+++ b/fit/osp_fitHERCULES.m
@@ -75,6 +75,7 @@ for kk = 1:MRSCont.nDatasets
             dataToFit.refFWHM   = fitParamsSum.refFWHM;
             
             if isfield(fitOpts, 'coMM3') && ~strcmp(fitOpts.coMM3, 'none')
+                fitOpts.CrFactor = 4;
                 [basisSetDiff1] = osp_addDiffMMPeaks(basisSetDiff1,basisSetSum,fitOpts);
             end
 

--- a/fit/osp_fitHERMES.m
+++ b/fit/osp_fitHERMES.m
@@ -75,6 +75,7 @@ for kk = 1:MRSCont.nDatasets
             dataToFit.refFWHM   = fitParamsSum.refFWHM;
             
             if isfield(fitOpts, 'coMM3') && ~strcmp(fitOpts.coMM3, 'none')
+                fitOpts.CrFactor = 4;
                 [basisSetDiff1] = osp_addDiffMMPeaks(basisSetDiff1,basisSetSum,fitOpts);
             end
 

--- a/fit/osp_fitMEGA.m
+++ b/fit/osp_fitMEGA.m
@@ -98,6 +98,7 @@ for kk = 1:MRSCont.nDatasets(1)
             dataToFit.refFWHM   = fitParamsOff.refFWHM;
 
             if ~strcmp(fitOpts.coMM3, 'none')
+                fitOpts.CrFactor = 1;
                 [basisSetDiff1] = osp_addDiffMMPeaks(basisSetDiff1,basisSetOff,fitOpts);
             end
 
@@ -272,6 +273,7 @@ for kk = 1:MRSCont.nDatasets(1)
                 basisSetDiff1 = MRSCont.fit.basisSet;
                 basisSetDiff1.fids = basisSetDiff1.fids(:,:,3);
                 basisSetDiff1.specs = basisSetDiff1.specs(:,:,3);
+                fitOpts.CrFactor = 1;
                 [basisSetDiff1] = osp_addDiffMMPeaks(basisSetDiff1,fitOpts);
                 basisSetConc.fids(:,:,1) = basisSetDiff1.fids(:,:);
                 basisSetConc.specs(:,:,1) = basisSetDiff1.specs(:,:);

--- a/libraries/FID-A/fitTools/fitModels/Osprey/osp_addDiffMMPeaks.m
+++ b/libraries/FID-A/fitTools/fitModels/Osprey/osp_addDiffMMPeaks.m
@@ -10,6 +10,8 @@ function [BASISdiff] = osp_addDiffMMPeaks(BASISdiff,BASISoff,fitOpts)
     % To scale the amplitudes correctly, we first need to determine the
     % area of the 3.027 ppm CH3 signal of creatine
     [CrArea] = detCrArea(BASISoff);
+    % Take into account whether off or sum spectrum is used
+    CrArea = CrArea/fitOpts.CrFactor;
     oneProtonArea = CrArea/3;
     
     % Next, we determine the area of a Gaussian singlet with nominal area 1
@@ -40,6 +42,18 @@ function [BASISdiff] = osp_addDiffMMPeaks(BASISdiff,BASISoff,fitOpts)
         BASISdiff.fids(:,idx_MM)  = BASISdiff.fids(:,idx_MM) +  MM3co.fids;
         BASISdiff.specs(:,idx_MM) = BASISdiff.specs(:,idx_MM) +  MM3co.specs;
     end   
+
+    if strcmp(fitOpts.coMM3, '3to2MMud') % 3:2 MM09 and co-edited MM3 model
+        idx_MM          = find(strcmp(BASISdiff.name,'MM09'));
+        if isempty(idx_MM)
+            error('No basis function with nametag ''MM09'' found! Abort!');
+        end
+        idx_MM2          = find(strcmp(BASISdiff.name,'MM30'));
+        BASISdiff.fids(:,idx_MM)  = BASISdiff.fids(:,idx_MM) +  BASISdiff.fids(:,idx_MM2);
+        BASISdiff.specs(:,idx_MM) = BASISdiff.specs(:,idx_MM) +  BASISdiff.specs(:,idx_MM2);
+        BASISdiff.fids(:,idx_MM2)  = zeros(length(BASISdiff.fids(:,idx_MM2)),1);
+        BASISdiff.specs(:,idx_MM2) = zeros(length(BASISdiff.specs(:,idx_MM2)),1);
+    end  
     
     if strcmp(fitOpts.coMM3, '3to2MMsoft') % 3:2 MM09 and co-edited MM3 model
         idx_MM          = find(strcmp(BASISdiff.name,'MM09'));


### PR DESCRIPTION
- Fixed the scaling of the co-edited MM peak at 3 ppm. Scaling issue was related to the on the flight calculation based on the sum spectrum while the initial MMs are calculated with the A sub spectrum. Therefore, this did not occur for MEGA or the older implementation prior to v.2.0.0.