### PR TITLE
[BUG FIX] - GUI crashes during load plot - osp_plotLoad - Gaelle Doucet

### DIFF
--- a/plot/osp_plotLoad.m
+++ b/plot/osp_plotLoad.m
@@ -296,8 +296,10 @@ if MRSCont.flags.isMEGA && ~(strcmp(which, 'w') || strcmp(which, 'ref')|| strcmp
 else if MRSCont.flags.isMEGA && (strcmp(which, 'w') || strcmp(which, 'ref')|| strcmp(which, 'mm_ref'))
     axesHandles.A = gca();
     nAvgs = dataToPlot.averages;
-    if nAvgs > dataToPlot.sz(dataToPlot.dims.averages)
-        nAvgs =dataToPlot.sz(dataToPlot.dims.averages);
+    if dataToPlot.dims.averages > 0
+        if nAvgs > dataToPlot.sz(dataToPlot.dims.averages)
+            nAvgs =dataToPlot.sz(dataToPlot.dims.averages);
+        end
     end
     % Loop over all averages
     for rr = 1:nAvgs


### PR DESCRIPTION
The crash was related to having a single average water scan which results in dims.averages = 0 and wrong indexing.

Fixed by having an additional case during the plot call.