### PR TITLE
[NEW FEATURE] - Process 'any' water scan as water reference - various…

### DIFF
--- a/libraries/FID-A/processingTools/op_combine_water_subspecs.m
+++ b/libraries/FID-A/processingTools/op_combine_water_subspecs.m
@@ -1,0 +1,44 @@
+
+function [out] = op_combine_water_subspecs(in,average)
+% Some formats end up having subspectra in their reference scans
+% (e.g. Philips), as well as empty lines. Intercept these cases
+% here.
+if nargin < 2
+    average = 1;
+end
+    out = in;
+    if out.subspecs == 2
+        raw_A               = op_takesubspec(out,1);
+        [raw_A]             = op_rmempty(raw_A);            % Remove empty lines
+        raw_B               = op_takesubspec(out,2);
+        [raw_B]             = op_rmempty(raw_B);            % Remove empty lines
+        out                 = op_concatAverages(raw_A,raw_B);
+    end
+
+    if out.subspecs == 4
+        raw_A               = op_takesubspec(out,1);
+        [raw_A]             = op_rmempty(raw_A);            % Remove empty lines
+        raw_B               = op_takesubspec(out,2);
+        [raw_B]             = op_rmempty(raw_B);            % Remove empty lines
+        raw_C               = op_takesubspec(out,3);
+        [raw_C]             = op_rmempty(raw_C);            % Remove empty lines
+        raw_D               = op_takesubspec(out,4);
+        [raw_D]             = op_rmempty(raw_D);            % Remove empty lines
+        out                 = op_concatAverages(op_concatAverages(raw_A,raw_B),op_concatAverages(raw_C,raw_D));
+    end
+    if out.subspecs == 1
+        [out]             = op_rmempty(out);            % Remove empty lines
+    end
+    if average
+        % Align and verage the refernce data
+        if out.averages > 1 && ~out.flags.averaged
+            [out]             = op_rmempty(out);
+            [out,~,~]               = op_alignAverages(out, 1, 'n');
+            out                     = op_averaging(out);            % Average
+        else
+            out.flags.averaged  = 1;
+            out.dims.averages   = 0;
+        end
+    end
+    out.names = {'A'};
+end

--- a/load/osp_LoadBrukerFid.m
+++ b/load/osp_LoadBrukerFid.m
@@ -137,51 +137,19 @@ for kk = 1:MRSCont.nDatasets(1)
                 ref_ll = MRSCont.opts.MultipleSpectra.ref(ll);
                 if MRSCont.flags.isUnEdited
                     raw_ref = io_loadspec_bruk(MRSCont.files_ref{ref_ll,kk},1);
-                    [raw_ref] = op_rmempty(raw_ref);
+                    raw_ref = op_combine_water_subspecs(raw_ref,0);
                     raw_ref.flags.isUnEdited = 1;                
                 elseif MRSCont.flags.isMEGA
                     raw_ref = io_loadspec_bruk(MRSCont.files_ref{ref_ll,kk},2);
-                    if raw_ref.subspecs > 1
-                        raw_ref_A               = op_takesubspec(raw_ref,1);
-                        [raw_ref_A]             = op_rmempty(raw_ref_A);            % Remove empty lines
-                        raw_ref_B               = op_takesubspec(raw_ref,2);
-                        [raw_ref_B]             = op_rmempty(raw_ref_B);            % Remove empty lines
-                        raw_ref                 = op_concatAverages(raw_ref_A,raw_ref_B);
-                    else
-                        [raw_ref] = op_rmempty(raw_ref);
-                    end
+                    raw_ref = op_combine_water_subspecs(raw_ref,0);
                     raw_ref.flags.isMEGA = 1;
                 elseif MRSCont.flags.isHERMES
                     raw_ref = io_loadspec_bruk(MRSCont.files_ref{ref_ll,kk},1);
-                    if raw_ref.subspecs > 1
-                        raw_ref_A               = op_takesubspec(raw_ref,1);
-                        [raw_ref_A]             = op_rmempty(raw_ref_A);            % Remove empty lines
-                        raw_ref_B               = op_takesubspec(raw_ref,2);
-                        [raw_ref_B]             = op_rmempty(raw_ref_B);            % Remove empty lines
-                        raw_ref_C               = op_takesubspec(raw_ref,3);
-                        [raw_ref_C]             = op_rmempty(raw_ref_C);            % Remove empty lines
-                        raw_ref_D               = op_takesubspec(raw_ref,4);
-                        [raw_ref_D]             = op_rmempty(raw_ref_D);            % Remove empty lines
-                        raw_ref                 = op_concatAverages(raw_ref_A,raw_ref_B,raw_ref_C,raw_ref_D);  
-                    else
-                        [raw_ref] = op_rmempty(raw_ref); 
-                    end
+                    raw_ref = op_combine_water_subspecs(raw_ref,0);
                     raw_ref.flags.isHERMES = 1;
                 elseif MRSCont.flags.isHERCULES
                     raw_ref = io_loadspec_bruk(MRSCont.files_ref{ref_ll,kk},1);
-                    if raw_ref.subspecs > 1
-                        raw_ref_A               = op_takesubspec(raw_ref,1);
-                        [raw_ref_A]             = op_rmempty(raw_ref_A);            % Remove empty lines
-                        raw_ref_B               = op_takesubspec(raw_ref,2);
-                        [raw_ref_B]             = op_rmempty(raw_ref_B);            % Remove empty lines
-                        raw_ref_C               = op_takesubspec(raw_ref,3);
-                        [raw_ref_C]             = op_rmempty(raw_ref_C);            % Remove empty lines
-                        raw_ref_D               = op_takesubspec(raw_ref,4);
-                        [raw_ref_D]             = op_rmempty(raw_ref_D);            % Remove empty lines
-                        raw_ref                 = op_concatAverages(raw_ref_A,raw_ref_B,raw_ref_C,raw_ref_D);  
-                    else
-                        [raw_ref] = op_rmempty(raw_ref); 
-                    end
+                    raw_ref = op_combine_water_subspecs(raw_ref,0);
                     raw_ref.flags.isHERCULES = 1;
                 end
                 MRSCont.raw_ref{ref_ll,kk}  = raw_ref;
@@ -189,6 +157,7 @@ for kk = 1:MRSCont.nDatasets(1)
             if MRSCont.flags.hasWater
                 w_ll = MRSCont.opts.MultipleSpectra.w(ll);
                 raw_w   = io_loadspec_bruk(MRSCont.files_w{w_ll,kk},1);
+                raw_w = op_combine_water_subspecs(raw_w,0);
                 raw_w.flags.isUnEdited = 1;
                 MRSCont.raw_w{w_ll,kk}    = raw_w;
             end

--- a/load/osp_LoadDICOM.m
+++ b/load/osp_LoadDICOM.m
@@ -78,19 +78,8 @@ for kk = 1:MRSCont.nDatasets(1)
             if MRSCont.flags.hasRef
                 ref_ll = MRSCont.opts.MultipleSpectra.ref(ll);
                 raw_ref = io_loadspec_dicom(MRSCont.files_ref{ref_ll,kk});
+                raw_ref = op_combine_water_subspecs(raw_ref,0);
                 MRSCont.raw_ref{ref_ll,kk}  = raw_ref;
-                if MRSCont.raw_ref{ref_ll,kk}.subspecs > 1
-                    if MRSCont.flags.isMEGA
-                        raw_ref_A               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},1);
-                        raw_ref_B               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},2);
-                        MRSCont.raw_ref{ref_ll,kk} = op_concatAverages(raw_ref_A,raw_ref_B);
-                    else
-                        raw_ref_A               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},1);
-                        raw_ref_B               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},2);
-                        raw_ref_C               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},3);
-                        raw_ref_D               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},4);                    
-                        MRSCont.raw_ref{ref_ll,kk} = op_concatAverages(op_concatAverages(raw_ref_A,raw_ref_B),op_concatAverages(raw_ref_C,raw_ref_D));
-                    end
                 end
                 if MRSCont.flags.isUnEdited
                     MRSCont.raw_ref{ref_ll,kk}.flags.isUnEdited = 1;
@@ -102,6 +91,7 @@ for kk = 1:MRSCont.nDatasets(1)
             if MRSCont.flags.hasWater
                 w_ll = MRSCont.opts.MultipleSpectra.w(ll);
                 raw_w   = io_loadspec_dicom(MRSCont.files_w{w_ll,kk});
+                raw_w = op_combine_water_subspecs(raw_w,0);
                 MRSCont.raw_w{w_ll,kk}    = raw_w;
                 if MRSCont.flags.isUnEdited
                     MRSCont.raw_w{w_ll,kk}.flags.isUnEdited = 1;

--- a/load/osp_LoadNII.m
+++ b/load/osp_LoadNII.m
@@ -96,10 +96,12 @@ for kk = 1:MRSCont.nDatasets(1)
                 MRSCont.raw{metab_ll,kk}      = raw;
 
                 if MRSCont.flags.hasRef
+                    raw_ref = op_combine_water_subspecs(raw_ref,0);
                     MRSCont.raw_ref{ref_ll,kk}  = raw_ref;
                 end
 
                 if MRSCont.flags.hasWater
+                    raw_w = op_combine_water_subspecs(raw_w,0);
                     MRSCont.raw_w{w_ll,kk}    = raw_w;
                 end
 

--- a/load/osp_LoadP.m
+++ b/load/osp_LoadP.m
@@ -47,18 +47,22 @@ for kk = 1:MRSCont.nDatasets(1)
             if MRSCont.flags.isUnEdited
                 [raw, raw_ref]  = io_loadspec_GE(MRSCont.files{metab_ll,kk},1);
                 raw.flags.UnEdited = 1;
+                raw_ref = op_combine_water_subspecs(raw_ref,0);
                 raw_ref.flags.UnEdited = 1;
             elseif MRSCont.flags.isMEGA
                 [raw, raw_ref]  = io_loadspec_GE(MRSCont.files{metab_ll,kk},2);
                 raw.flags.isMEGA = 1;
+                raw_ref = op_combine_water_subspecs(raw_ref,0);
                 raw_ref.flags.isMEGA = 1;
             elseif MRSCont.flags.isHERMES
                 [raw, raw_ref]  = io_loadspec_GE(MRSCont.files{metab_ll,kk},4);
                 raw.flags.isHERMES = 1;
+                raw_ref = op_combine_water_subspecs(raw_ref,0);
                 raw_ref.flags.isHERMES = 1;
             elseif MRSCont.flags.isHERCULES
                 [raw, raw_ref]  = io_loadspec_GE(MRSCont.files{metab_ll,kk},4);
                 raw.flags.isHERCULES = 1;
+                raw_ref = op_combine_water_subspecs(raw_ref,0);
                 raw_ref.flags.isHERCULES = 1;
             end
             MRSCont.raw_uncomb{metab_ll,kk}      = raw;

--- a/load/osp_LoadRAW.m
+++ b/load/osp_LoadRAW.m
@@ -87,6 +87,7 @@ for kk = 1:MRSCont.nDatasets(1)
                 ref_ll = MRSCont.opts.MultipleSpectra.ref(ll);
                 if MRSCont.flags.isUnEdited
                     raw_ref = io_loadspec_lcmraw(MRSCont.files_ref{ref_ll,kk});
+                    raw_ref = op_combine_water_subspecs(raw_ref,0);
                     raw_ref.flags.isUnEdited = 1;
                 end
                 MRSCont.raw_ref{ref_ll,kk}  = raw_ref;
@@ -96,6 +97,7 @@ for kk = 1:MRSCont.nDatasets(1)
             if MRSCont.flags.hasWater
                 w_ll = MRSCont.opts.MultipleSpectra.w(ll);
                 raw_w   = io_loadspec_lcmraw(MRSCont.files_w{w_ll,kk});
+                raw_w = op_combine_water_subspecs(raw_w,0);
                 raw_w.flags.isUnEdited = 1;
                 MRSCont.raw_w{w_ll,kk}    = raw_w;
             end

--- a/load/osp_LoadRDA.m
+++ b/load/osp_LoadRDA.m
@@ -78,20 +78,8 @@ for kk = 1:MRSCont.nDatasets(1)
             if MRSCont.flags.hasRef
                 ref_ll = MRSCont.opts.MultipleSpectra.ref(ll);
                 raw_ref = io_loadspec_rda(MRSCont.files_ref{ref_ll,kk});
+                raw_ref = op_combine_water_subspecs(raw_ref,0);
                 MRSCont.raw_ref{ref_ll,kk}  = raw_ref;
-                if MRSCont.raw_ref{ref_ll,kk}.subspecs > 1
-                    if MRSCont.flags.isMEGA
-                        raw_ref_A               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},1);
-                        raw_ref_B               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},2);
-                        MRSCont.raw_ref{ref_ll,kk} = op_concatAverages(raw_ref_A,raw_ref_B);
-                    else
-                        raw_ref_A               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},1);
-                        raw_ref_B               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},2);
-                        raw_ref_C               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},3);
-                        raw_ref_D               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},4);                    
-                        MRSCont.raw_ref{ref_ll,kk} = op_concatAverages(raw_ref_A,raw_ref_B,raw_ref_C,raw_ref_D);
-                    end
-                end
                 if MRSCont.flags.isUnEdited
                     MRSCont.raw_ref{ref_ll,kk}.flags.isUnEdited = 1;
                 end
@@ -102,6 +90,7 @@ for kk = 1:MRSCont.nDatasets(1)
             if MRSCont.flags.hasWater
                 w_ll = MRSCont.opts.MultipleSpectra.w(ll);
                 raw_w   = io_loadspec_rda(MRSCont.files_w{w_ll,kk});
+                raw_w = op_combine_water_subspecs(raw_w,0);
                 MRSCont.raw_w{w_ll,kk}    = raw_w;
                 if MRSCont.flags.isUnEdited
                     MRSCont.raw_w{w_ll,kk}.flags.isUnEdited = 1;
@@ -113,6 +102,7 @@ for kk = 1:MRSCont.nDatasets(1)
             if MRSCont.flags.hasMM
                 temp_ll = MRSCont.opts.MultipleSpectra.mm(ll);
                 raw_mm   = io_loadspec_rda(MRSCont.files_mm{temp_ll,kk});
+                raw_mm = op_combine_water_subspecs(raw_mm,0);
                 MRSCont.raw_mm{temp_ll,kk}    = raw_mm;
                 if MRSCont.flags.isUnEdited
                     MRSCont.raw_mm{temp_ll,kk}.flags.isUnEdited = 1;

--- a/load/osp_LoadSDAT.m
+++ b/load/osp_LoadSDAT.m
@@ -110,51 +110,19 @@ for kk = 1:MRSCont.nDatasets(1)
                 ref_ll = MRSCont.opts.MultipleSpectra.ref(ll);
                 if MRSCont.flags.isUnEdited                    
                     raw_ref = io_loadspec_sdat(MRSCont.files_ref{ref_ll,kk},1);
-                    [raw_ref] = op_rmempty(raw_ref);
+                    raw_ref = op_combine_water_subspecs(raw_ref,0);
                     raw_ref.flags.isUnEdited = 1;
                 elseif MRSCont.flags.isMEGA
                     raw_ref = io_loadspec_sdat(MRSCont.files_ref{ref_ll,kk},2);
-                    if raw_ref.subspecs > 1
-                        raw_ref_A               = op_takesubspec(raw_ref,1);
-                        [raw_ref_A]             = op_rmempty(raw_ref_A);            % Remove empty lines
-                        raw_ref_B               = op_takesubspec(raw_ref,2);
-                        [raw_ref_B]             = op_rmempty(raw_ref_B);            % Remove empty lines
-                        raw_ref                 = op_concatAverages(raw_ref_A,raw_ref_B);
-                    else
-                        [raw_ref] = op_rmempty(raw_ref);
-                    end
+                    raw_ref = op_combine_water_subspecs(raw_ref,0);
                     raw_ref.flags.isMEGA = 1;
                 elseif MRSCont.flags.isHERMES
                     raw_ref = io_loadspec_sdat(MRSCont.files_ref{ref_ll,kk},1);
-                    if raw_ref.subspecs > 1
-                        raw_ref_A               = op_takesubspec(raw_ref,1);
-                        [raw_ref_A]             = op_rmempty(raw_ref_A);            % Remove empty lines
-                        raw_ref_B               = op_takesubspec(raw_ref,2);
-                        [raw_ref_B]             = op_rmempty(raw_ref_B);            % Remove empty lines
-                        raw_ref_C               = op_takesubspec(raw_ref,3);
-                        [raw_ref_C]             = op_rmempty(raw_ref_C);            % Remove empty lines
-                        raw_ref_D               = op_takesubspec(raw_ref,4);
-                        [raw_ref_D]             = op_rmempty(raw_ref_D);            % Remove empty lines
-                        raw_ref                 = op_concatAverages(raw_ref_A,raw_ref_B,raw_ref_C,raw_ref_D);  
-                    else
-                        [raw_ref] = op_rmempty(raw_ref); 
-                    end
+                    raw_ref = op_combine_water_subspecs(raw_ref,0);
                     raw_ref.flags.isHERMES = 1;
                  elseif MRSCont.flags.isHERCULES
                     raw_ref = io_loadspec_sdat(MRSCont.files_ref{ref_ll,kk},1);
-                    if raw_ref.subspecs > 1
-                        raw_ref_A               = op_takesubspec(raw_ref,1);
-                        [raw_ref_A]             = op_rmempty(raw_ref_A);            % Remove empty lines
-                        raw_ref_B               = op_takesubspec(raw_ref,2);
-                        [raw_ref_B]             = op_rmempty(raw_ref_B);            % Remove empty lines
-                        raw_ref_C               = op_takesubspec(raw_ref,3);
-                        [raw_ref_C]             = op_rmempty(raw_ref_C);            % Remove empty lines
-                        raw_ref_D               = op_takesubspec(raw_ref,4);
-                        [raw_ref_D]             = op_rmempty(raw_ref_D);            % Remove empty lines
-                        raw_ref                 = op_concatAverages(raw_ref_A,raw_ref_B,raw_ref_C,raw_ref_D);  
-                    else
-                        [raw_ref] = op_rmempty(raw_ref); 
-                    end 
+                    raw_ref = op_combine_water_subspecs(raw_ref,0);
                     raw_ref.flags.isHERCULES = 1;
                 end
                 MRSCont.raw_ref{ref_ll,kk}  = raw_ref;
@@ -162,6 +130,7 @@ for kk = 1:MRSCont.nDatasets(1)
             if MRSCont.flags.hasWater
                 w_ll = MRSCont.opts.MultipleSpectra.w(ll);
                 raw_w   = io_loadspec_sdat(MRSCont.files_w{w_ll,kk},1);
+                raw_w = op_combine_water_subspecs(raw_w,0);
                 raw_w.flags.isUnEdited = 1;
                 MRSCont.raw_w{w_ll,kk}    = raw_w;
             end
@@ -171,51 +140,19 @@ for kk = 1:MRSCont.nDatasets(1)
                 temp_ll = MRSCont.opts.MultipleSpectra.mm_ref(ll);
                 if MRSCont.flags.isUnEdited
                     raw_mm_ref = io_loadspec_sdat(MRSCont.files_mm_ref{temp_ll,kk},1);
-                    [raw_mm_ref] = op_rmempty(raw_mm_ref);
+                    raw_mm_ref = op_combine_water_subspecs(raw_mm_ref,0);
                     raw_mm_ref.flags.isUnEdited = 1;
                 elseif MRSCont.flags.isMEGA
                     raw_mm_ref = io_loadspec_sdat(MRSCont.files_mm_ref{temp_ll,kk},2);
-                    if raw_mm_ref.subspecs > 1
-                        raw_mm_ref_A               = op_takesubspec(raw_mm_ref,1);
-                        [raw_mm_ref_A]             = op_rmempty(raw_mm_ref_A);            % Remove empty lines
-                        raw_mm_ref_B               = op_takesubspec(raw_mm_ref,2);
-                        [raw_mm_ref_B]             = op_rmempty(raw_mm_ref_B);            % Remove empty lines
-                        raw_mm_ref                 = op_concatAverages(raw_mm_ref_A,raw_mm_ref_B);
-                    else
-                        [raw_mm_ref] = op_rmempty(raw_mm_ref);
-                    end
+                    raw_mm_ref = op_combine_water_subspecs(raw_mm_ref,0);
                     raw_mm_ref.flags.isMEGA = 1;
                 elseif MRSCont.flags.isHERMES
                     raw_mm_ref = io_loadspec_sdat(MRSCont.files_mm_ref{temp_ll,kk},1);
-                    if raw_mm_ref.subspecs > 1
-                        raw_mm_ref_A               = op_takesubspec(raw_mm_ref,1);
-                        [raw_mm_ref_A]             = op_rmempty(raw_mm_ref_A);            % Remove empty lines
-                        raw_mm_ref_B               = op_takesubspec(raw_mm_ref,2);
-                        [raw_mm_ref_B]             = op_rmempty(raw_mm_ref_B);            % Remove empty lines
-                        raw_mm_ref_C               = op_takesubspec(raw_mm_ref,3);
-                        [raw_mm_ref_C]             = op_rmempty(raw_mm_ref_C);            % Remove empty lines
-                        raw_mm_ref_D               = op_takesubspec(raw_mm_ref,4);
-                        [raw_mm_ref_D]             = op_rmempty(raw_mm_ref_D);            % Remove empty lines
-                        raw_mm_ref                 = op_concatAverages(raw_mm_ref_A,raw_mm_ref_B,raw_mm_ref_C,raw_mm_ref_D);  
-                    else
-                        [raw_mm_ref] = op_rmempty(raw_mm_ref); 
-                    end
+                    raw_mm_ref = op_combine_water_subspecs(raw_mm_ref,0);
                     raw_mm_ref.flags.isHERMES = 1;
                  elseif MRSCont.flags.isHERCULES
                     raw_mm_ref = io_loadspec_sdat(MRSCont.files_mm_ref{temp_ll,kk},1);
-                    if raw_mm_ref.subspecs > 1
-                        raw_mm_ref_A               = op_takesubspec(raw_mm_ref,1);
-                        [raw_mm_ref_A]             = op_rmempty(raw_mm_ref_A);            % Remove empty lines
-                        raw_mm_ref_B               = op_takesubspec(raw_mm_ref,2);
-                        [raw_mm_ref_B]             = op_rmempty(raw_mm_ref_B);            % Remove empty lines
-                        raw_mm_ref_C               = op_takesubspec(raw_mm_ref,3);
-                        [raw_mm_ref_C]             = op_rmempty(raw_mm_ref_C);            % Remove empty lines
-                        raw_mm_ref_D               = op_takesubspec(raw_mm_ref,4);
-                        [raw_mm_ref_D]             = op_rmempty(raw_mm_ref_D);            % Remove empty lines
-                        raw_mm_ref                 = op_concatAverages(raw_mm_ref_A,raw_mm_ref_B,raw_mm_ref_C,raw_mm_ref_D);  
-                    else
-                        [raw_mm_ref] = op_rmempty(raw_mm_ref); 
-                    end 
+                    raw_mm_ref = op_combine_water_subspecs(raw_mm_ref,0);
                     raw_mm_ref.flags.isHERCULES = 1;
                 end
                 MRSCont.raw_mm_ref{temp_ll,kk}  = raw_mm_ref;

--- a/process/OspreyProcess.m
+++ b/process/OspreyProcess.m
@@ -121,7 +121,7 @@ for kk = 1:MRSCont.nDatasets(1) %Subject loop
             if MRSCont.flags.hasMMRef
                 mm_ref_ll = MRSCont.opts.MultipleSpectra.mm_ref(ll);
                 raw_mm_ref = MRSCont.raw_mm_ref{mm_ref_ll,kk};              % Get the kk-th dataset
-                raw_mm_ref = combine_water_subspecs(raw_mm_ref);
+                raw_mm_ref = op_combine_water_subspecs(raw_mm_ref);
             end
             
 %%          %%% 1D. GET REFERENCE DATA %%%
@@ -134,7 +134,7 @@ for kk = 1:MRSCont.nDatasets(1) %Subject loop
                     raw_ref = combine_special_subspecs(raw_ref);
                 end
             
-                raw_ref = combine_water_subspecs(raw_ref);                
+                raw_ref = op_combine_water_subspecs(raw_ref);                
             end
 
 %%           %%% 1E. GET SHORT-TE WATER DATA %%%
@@ -157,7 +157,7 @@ for kk = 1:MRSCont.nDatasets(1) %Subject loop
                 end
 
                 if raw_w.subspecs > 1
-                    raw_w = combine_water_subspecs(raw_w);
+                    raw_w = op_combine_water_subspecs(raw_w);
                 end
                 if ~MRSCont.flags.isMRSI
                     [raw_w,~]                       = op_eccKlose(raw_w, raw_w);        % Klose eddy current correction
@@ -800,43 +800,6 @@ end
 
 
 %% Functions for processing
-
-function [raw] = combine_water_subspecs(raw)
-% Some formats end up having subspectra in their reference scans
-% (e.g. Philips), as well as empty lines. Intercept these cases
-% here.
-    if raw.subspecs == 2
-        raw_A               = op_takesubspec(raw,1);
-        [raw_A]             = op_rmempty(raw_A);            % Remove empty lines
-        raw_B               = op_takesubspec(raw,2);
-        [raw_B]             = op_rmempty(raw_B);            % Remove empty lines
-        raw                 = op_concatAverages(raw_A,raw_B);
-    end
-
-    if raw.subspecs == 4
-        raw_A               = op_takesubspec(raw,1);
-        [raw_A]             = op_rmempty(raw_A);            % Remove empty lines
-        raw_B               = op_takesubspec(raw,2);
-        [raw_B]             = op_rmempty(raw_B);            % Remove empty lines
-        raw_C               = op_takesubspec(raw,3);
-        [raw_C]             = op_rmempty(raw_C);            % Remove empty lines
-        raw_D               = op_takesubspec(raw,4);
-        [raw_D]             = op_rmempty(raw_D);            % Remove empty lines
-        raw                 = op_concatAverages(op_concatAverages(raw_A,raw_B),op_concatAverages(raw_C,raw_D));
-    end
-
-    % Align and verage the refernce data
-    if raw.averages > 1 && ~raw.flags.averaged
-        [raw]             = op_rmempty(raw);
-        [raw,~,~]               = op_alignAverages(raw, 1, 'n');
-        raw                     = op_averaging(raw);            % Average
-    else
-        raw.flags.averaged  = 1;
-        raw.dims.averages   = 0;
-    end
-    raw.names = {'A'};
-end
-
 function [raw] = combine_special_subspecs(raw)
 % For SPECIAL-localized data, we adopt the pipeline from 
 % https://github.com/CIC-methods/FID-A/blob/master/exampleRunScripts/run_specialproc_auto.m

--- a/process/osp_combineCoils.m
+++ b/process/osp_combineCoils.m
@@ -77,54 +77,58 @@ if nargin<5
                 
                 MRSCont.raw{ll,kk}     = raw_comb;
                 MRSCont.raw_ref{ll,kk} = raw_ref_comb;
-                if MRSCont.raw_ref{ll,kk}.subspecs > 1 && ~isSpecial
-                    if MRSCont.flags.isMEGA
-                        raw_ref_A               = op_takesubspec(MRSCont.raw_ref{ll,kk},1);
-                        raw_ref_B               = op_takesubspec(MRSCont.raw_ref{ll,kk},2);
-                        MRSCont.raw_ref{ll,kk} = op_concatAverages(raw_ref_A,raw_ref_B);
+                if ~isSpecial
+                    MRSCont.raw_ref{ll,kk} = op_combine_water_subspecs(MRSCont.raw_ref{ll,kk},0);
+                end
+                
+            else if MRSCont.flags.hasWater
+                        if isSpecial
+                            % Workflow adopted from https://github.com/CIC-methods/FID-A/blob/master/exampleRunScripts/run_specialproc_auto.m
+                            cweights_w          = op_getcoilcombos(op_combinesubspecs(MRSCont.raw_w_uncomb{ll,kk}, 'diff'), 1, 'h');
+                        else
+                            cweights_w          = op_getcoilcombos(MRSCont.raw_w_uncomb{ll,kk}, 1, 'h');
+                        end
+                        raw_comb            = op_addrcvrs(MRSCont.raw_uncomb{ll,kk},1,'h',cweights_w);
+                        if MRSCont.flags.isUnEdited
+                            raw_comb.flags.isUnEdited = 1;
+                        elseif MRSCont.flags.isMEGA
+                            raw_comb.flags.isMEGA = 1;
+                        elseif MRSCont.flags.isHERMES
+                            raw_comb.flags.isHERMES = 1;
+                        elseif MRSCont.flags.isHERCULES
+                            raw_comb.flags.isHERCULES = 1;
+                        end
+                        MRSCont.raw{ll,kk}     = raw_comb;
+    
+    
+                        raw_w_comb          = op_addrcvrs(MRSCont.raw_w_uncomb{ll,kk},1,'h',cweights_w);
+                        raw_w_comb.flags.isUnEdited = 1;
+                        MRSCont.raw_w{ll,kk}   = raw_w_comb;
+                        MRSCont.raw_w{ll,kk} = op_combine_water_subspecs(MRSCont.raw_w{ll,kk},0);
+                else
+                    
+        
+                    % if not, use the metabolite scan itself
+                    if isSpecial
+                        % Workflow adopted from https://github.com/CIC-methods/FID-A/blob/master/exampleRunScripts/run_specialproc_auto.m
+                        cweights          = op_getcoilcombos_specReg(op_combinesubspecs(op_averaging(MRSCont.raw_uncomb{ll,kk}), 'diff'), 0, 0.01, 2);
                     else
-                        raw_ref_A               = op_takesubspec(MRSCont.raw_ref{ll,kk},1);
-                        raw_ref_B               = op_takesubspec(MRSCont.raw_ref{ll,kk},2);
-                        raw_ref_C               = op_takesubspec(MRSCont.raw_ref{ll,kk},3);
-                        raw_ref_D               = op_takesubspec(MRSCont.raw_ref{ll,kk},4);
-                        MRSCont.raw_ref{ll,kk} = op_concatAverages(op_concatAverages(raw_ref_A,raw_ref_B),op_concatAverages(raw_ref_C,raw_ref_D));
+                        cweights          = op_getcoilcombos(MRSCont.raw_uncomb{ll,kk}, 1, 'h');
                     end
+                    
+                    raw_comb            = op_addrcvrs(MRSCont.raw_uncomb{ll,kk},1,'h',cweights);
+                    if MRSCont.flags.isUnEdited
+                        raw_comb.flags.isUnEdited = 1;
+                    elseif MRSCont.flags.isMEGA
+                        raw_comb.flags.isMEGA = 1;
+                    elseif MRSCont.flags.isHERMES
+                        raw_comb.flags.isHERMES = 1;
+                    elseif MRSCont.flags.isHERCULES
+                        raw_comb.flags.isHERCULES = 1;
+                    end
+                    MRSCont.raw{ll,kk}     = raw_comb;
                 end
-                
-            else
-                
-                % if not, use the metabolite scan itself
-                if isSpecial
-                    % Workflow adopted from https://github.com/CIC-methods/FID-A/blob/master/exampleRunScripts/run_specialproc_auto.m
-                    cweights          = op_getcoilcombos_specReg(op_combinesubspecs(op_averaging(MRSCont.raw_uncomb{ll,kk}), 'diff'), 0, 0.01, 2);
-                else
-                    cweights          = op_getcoilcombos(MRSCont.raw_uncomb{ll,kk}, 1, 'h');
-                end
-                
-                raw_comb            = op_addrcvrs(MRSCont.raw_uncomb{ll,kk},1,'h',cweights);
-                if MRSCont.flags.isUnEdited
-                    raw_comb.flags.isUnEdited = 1;
-                elseif MRSCont.flags.isMEGA
-                    raw_comb.flags.isMEGA = 1;
-                elseif MRSCont.flags.isHERMES
-                    raw_comb.flags.isHERMES = 1;
-                elseif MRSCont.flags.isHERCULES
-                    raw_comb.flags.isHERCULES = 1;
-                end
-                MRSCont.raw{ll,kk}     = raw_comb;
-            end
             
-            % Now do the same for the (short-TE) water signal
-            if MRSCont.flags.hasWater
-                if isSpecial
-                    % Workflow adopted from https://github.com/CIC-methods/FID-A/blob/master/exampleRunScripts/run_specialproc_auto.m
-                    cweights_w          = op_getcoilcombos(op_combinesubspecs(MRSCont.raw_w_uncomb{ll,kk}, 'diff'), 1, 'h');
-                else
-                    cweights_w          = op_getcoilcombos(MRSCont.raw_w_uncomb{ll,kk}, 1, 'h');
-                end
-                raw_w_comb          = op_addrcvrs(MRSCont.raw_w_uncomb{ll,kk},1,'h',cweights_w);
-                raw_w_comb.flags.isUnEdited = 1;
-                MRSCont.raw_w{ll,kk}   = raw_w_comb;
             end
         end
         
@@ -163,17 +167,7 @@ else
             MRSCont.raw{ll,kk}     = raw_comb;
             MRSCont.raw_ref{ref_ll,kk} = raw_ref_comb;
             if MRSCont.raw_ref{ref_ll,kk}.subspecs > 1 && ~isSpecial && (length(size(MRSCont.raw_ref{ref_ll,kk}.fids)) > 2)
-                if MRSCont.flags.isMEGA
-                    raw_ref_A               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},1);
-                    raw_ref_B               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},2);
-                    MRSCont.raw_ref{ref_ll,kk} = op_concatAverages(raw_ref_A,raw_ref_B);
-                else
-                    raw_ref_A               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},1);
-                    raw_ref_B               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},2);
-                    raw_ref_C               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},3);
-                    raw_ref_D               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},4);
-                    MRSCont.raw_ref{ref_ll,kk} = op_concatAverages(op_concatAverages(raw_ref_A,raw_ref_B),op_concatAverages(raw_ref_C,raw_ref_D));
-                end
+                MRSCont.raw_ref{ll,kk} = op_combine_water_subspecs(MRSCont.raw_ref{ll,kk},0);
             else
                 % Maintain spatial sub-spectra for SPECIAL-localized data.
                 if ~isSpecial
@@ -210,17 +204,7 @@ else
             MRSCont.raw{kk}     = raw_comb;
             MRSCont.raw_ref{ref_ll,kk} = raw_ref_comb;
             if MRSCont.raw_ref{ref_ll,kk}.subspecs > 1 && ~isSpecial && (length(size(MRSCont.raw_ref{ref_ll,kk}.fids)) > 2)
-                if MRSCont.flags.isMEGA
-                    raw_ref_A               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},1);
-                    raw_ref_B               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},2);
-                    MRSCont.raw_ref{ref_ll,kk} = op_concatAverages(raw_ref_A,raw_ref_B);
-                else
-                    raw_ref_A               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},1);
-                    raw_ref_B               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},2);
-                    raw_ref_C               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},3);
-                    raw_ref_D               = op_takesubspec(MRSCont.raw_ref{ref_ll,kk},4);
-                    MRSCont.raw_ref{ref_ll,kk} = op_concatAverages(op_concatAverages(raw_ref_A,raw_ref_B),op_concatAverages(raw_ref_C,raw_ref_D));
-                end
+                MRSCont.raw_ref{ll,kk} = op_combine_water_subspecs(MRSCont.raw_ref{ll,kk},0);
             else
                 % Maintain spatial sub-spectra for SPECIAL-localized data.
                 if ~isSpecial
@@ -230,39 +214,51 @@ else
             end
         end
         
-    else
-        % if not, use the metabolite scan itself
-        if isSpecial
-            % Workflow adopted from https://github.com/CIC-methods/FID-A/blob/master/exampleRunScripts/run_specialproc_auto.m
-            cweights          = op_getcoilcombos_specReg(op_combinesubspecs(op_averaging(MRSCont.raw_uncomb{ll,kk}), 'diff'), 0, 0.01, 2);
-        else
-            cweights          = op_getcoilcombos(MRSCont.raw_uncomb{ll,kk}, 1, 'h');
-        end
-        raw_comb            = op_addrcvrs(MRSCont.raw_uncomb{ll,kk},1,'h',cweights);
-        if MRSCont.flags.isUnEdited
-            raw_comb.flags.isUnEdited = 1;
-        elseif MRSCont.flags.isMEGA
-            raw_comb.flags.isMEGA = 1;
-        elseif MRSCont.flags.isHERMES
-            raw_comb.flags.isHERMES = 1;
-        elseif MRSCont.flags.isHERCULES
-            raw_comb.flags.isHERCULES = 1;
-        end
-        MRSCont.raw{ll,kk}     = raw_comb;
-    end
+    else if MRSCont.flags.hasWater % Now do the same for the (short-TE) water signal
+            if isSpecial
+                % Workflow adopted from https://github.com/CIC-methods/FID-A/blob/master/exampleRunScripts/run_specialproc_auto.m
+                cweights_w          = op_getcoilcombos(op_combinesubspecs(MRSCont.raw_w_uncomb{w_ll,kk}, 'diff'), 1, 'h');
+            else
+                cweights_w          = op_getcoilcombos(MRSCont.raw_w_uncomb{w_ll,kk}, 1, 'h');
+            end
+            raw_w_comb          = op_addrcvrs(MRSCont.raw_w_uncomb{w_ll,kk},1,'h',cweights_w);
+            
+            raw_comb            = op_addrcvrs(MRSCont.raw_uncomb{ll,kk},1,'h',cweights_w);
+            if MRSCont.flags.isUnEdited
+                raw_comb.flags.isUnEdited = 1;
+            elseif MRSCont.flags.isMEGA
+                raw_comb.flags.isMEGA = 1;
+            elseif MRSCont.flags.isHERMES
+                raw_comb.flags.isHERMES = 1;
+            elseif MRSCont.flags.isHERCULES
+                raw_comb.flags.isHERCULES = 1;
+            end
+            MRSCont.raw{ll,kk}     = raw_comb;
     
-    % Now do the same for the (short-TE) water signal
-    if MRSCont.flags.hasWater
-        if isSpecial
-            % Workflow adopted from https://github.com/CIC-methods/FID-A/blob/master/exampleRunScripts/run_specialproc_auto.m
-            cweights_w          = op_getcoilcombos(op_combinesubspecs(MRSCont.raw_w_uncomb{w_ll,kk}, 'diff'), 1, 'h');
+            raw_w_comb.flags.isUnEdited = 1;
+            MRSCont.raw_w{w_ll,kk}   = raw_w_comb;
+            MRSCont.raw_w{ll,kk} = op_combine_water_subspecs(MRSCont.raw_w{ll,kk},0);
         else
-            cweights_w          = op_getcoilcombos(MRSCont.raw_w_uncomb{w_ll,kk}, 1, 'h');
+            % if not, use the metabolite scan itself
+            if isSpecial
+                % Workflow adopted from https://github.com/CIC-methods/FID-A/blob/master/exampleRunScripts/run_specialproc_auto.m
+                cweights          = op_getcoilcombos_specReg(op_combinesubspecs(op_averaging(MRSCont.raw_uncomb{ll,kk}), 'diff'), 0, 0.01, 2);
+            else
+                cweights          = op_getcoilcombos(MRSCont.raw_uncomb{ll,kk}, 1, 'h');
+            end
+            raw_comb            = op_addrcvrs(MRSCont.raw_uncomb{ll,kk},1,'h',cweights);
+            if MRSCont.flags.isUnEdited
+                raw_comb.flags.isUnEdited = 1;
+            elseif MRSCont.flags.isMEGA
+                raw_comb.flags.isMEGA = 1;
+            elseif MRSCont.flags.isHERMES
+                raw_comb.flags.isHERMES = 1;
+            elseif MRSCont.flags.isHERCULES
+                raw_comb.flags.isHERCULES = 1;
+            end
+            MRSCont.raw{ll,kk}     = raw_comb;
         end
-        raw_w_comb          = op_addrcvrs(MRSCont.raw_w_uncomb{w_ll,kk},1,'h',cweights_w);
-        raw_w_comb.flags.isUnEdited = 1;
-        MRSCont.raw_w{w_ll,kk}   = raw_w_comb;
-    end
+    end        
 end
 %% Clean up and save
 


### PR DESCRIPTION
… load functions - Muhammad Saleh

- You can add any water scan as water reference now.
- Introduced a new function that combines subspectra from the water scan during the loading
- Additionally, added a case for the coil-combination to use the water reference scan if no lineshape reference is provided.