### PR TITLE
[FEATURE] - Add basis and remove noise scan - Gaelle Doucet

### DIFF
--- a/process/OspreyProcess.m
+++ b/process/OspreyProcess.m
@@ -338,7 +338,11 @@ for kk = 1:MRSCont.nDatasets(1) %Subject loop
                 if MRSCont.opts.ECC.raw(metab_ll,kk)
                     [raw,raw_ref]                   = op_eccKlose(raw, raw_ref);        % Klose eddy current correction
                 else
-                    [~,raw_ref]                   = op_eccKlose(raw, raw_ref);        % Klose eddy current correction
+                    try
+                        [~,raw_ref]                   = op_eccKlose(raw, raw_ref);        % Klose eddy current correction
+                    catch
+                        [~,raw_ref]                   = op_eccKlose(raw_ref, raw_ref);        % Klose eddy current correction
+                    end
                 end
                 [raw_ref,~]                     = op_ppmref(raw_ref,4.6,4.8,4.68);  % Reference to water @ 4.68 ppm
                 MRSCont.processed.ref{metab_ll,kk}       = raw_ref;                          % Save back to MRSCont container

--- a/process/osp_remove_noise_scan.m
+++ b/process/osp_remove_noise_scan.m
@@ -1,0 +1,29 @@
+function [MRSCont] = osp_remove_noise_scan(MRSCont)
+%% MRSCont = osp_remove_noise_scan(MRSCont)
+%   This function removes the noise reference from the raw data which is
+%   added to the raw data acquired with the CMRR sequence (if the flag is
+%   set to include a water and noise reference). The function should be
+%   called after running OspreyLoad.
+%
+%   USAGE:
+%       MRSCont = osp_remove_noise_scan(MRSCont)
+%
+%   INPUTS:
+%      MRSCont     = Osprey MRS container
+%
+%   OUTPUTS:
+%      MRSCont     = Osprey MRS container
+%
+%   AUTHORS:
+%       Dr. Helge Zoellner (Johns Hopkins University, 2022-07-05)
+%       hzoelln2@jh.edu
+%  
+%%
+for kk = 1 : MRSCont.nDatasets
+    MRSCont.raw_ref{kk}.fids(:,2) = [];
+    MRSCont.raw_ref{kk}.specs(:,2) = [];
+    MRSCont.raw_ref{kk}.sz(2) = 1;
+    MRSCont.raw_ref{kk}.averages = 1;
+end
+
+end


### PR DESCRIPTION
- Added a 40 ms sLASER Siemens unedited basis set
- Added a new function (osp_remove_noise_scan) to remove noise reference scans from the CMRR sequence. This has to be run before OspreyProcess to remove the noise reference scan.