### PR TITLE
[BUG FIX] - GUI crash during Load window - ? - Koen Cuypers

### DIFF
--- a/libraries/FID-A/inputOutput/io_loadspec_sdat.m
+++ b/libraries/FID-A/inputOutput/io_loadspec_sdat.m
@@ -26,15 +26,18 @@
 % OUTPUTS:
 % out        = Input dataset in FID-A structure format.
 
-function out = io_loadspec_sdat(filename,subspecs)
+function out = io_loadspec_sdat(filename,subspecs,series)
 
+if nargin<3
+    series = 0;
+end
 % Read in the data and header information
 [data, header] = philipsLoad(filename);
 
 % Determine the dimensions of the data
 data_size       = size(data);
 dims.t          = find(data_size == header.samples);
-if header.rows > 1 && header.averages > 1
+if (header.rows > 1 && header.averages > 1) && series
     if length(data_size) > 2 % Data has averages and series
         dims.averages   = find(data_size == header.averages);
         dims.extras   = find(data_size == header.rows);
@@ -52,7 +55,7 @@ if (isfield(header, 'nr_of_slices_for_multislice') && header.nr_of_slices_for_mu
     dims.Zvoxels = 3;
     dims.averages = 2;
     dims.extras = 0;
-else if header.rows > 1 && header.averages > 1
+else if (header.rows > 1 && header.averages > 1) && series
         if length(data_size) > 2 % Data has averages and series
             data = permute(data ,[dims.t dims.extras dims.averages]);
             dims.averages = 2;

--- a/load/osp_LoadSDAT.m
+++ b/load/osp_LoadSDAT.m
@@ -71,16 +71,16 @@ for kk = 1:MRSCont.nDatasets(1)
             % type of sequence needs to be differentiated here already.
             metab_ll = MRSCont.opts.MultipleSpectra.metab(ll);
             if MRSCont.flags.isUnEdited
-                raw         = io_loadspec_sdat(MRSCont.files{metab_ll,kk},1);
+                raw         = io_loadspec_sdat(MRSCont.files{metab_ll,kk},1,MRSCont.flags.isSERIES);
                 raw.flags.isUnEdited = 1;
             elseif MRSCont.flags.isMEGA
-                raw         = io_loadspec_sdat(MRSCont.files{metab_ll,kk},2);
+                raw         = io_loadspec_sdat(MRSCont.files{metab_ll,kk},2,MRSCont.flags.isSERIES);
                 raw.flags.isMEGA = 1;
             elseif MRSCont.flags.isHERMES
-                raw         = io_loadspec_sdat(MRSCont.files{metab_ll,kk},4);
+                raw         = io_loadspec_sdat(MRSCont.files{metab_ll,kk},4,MRSCont.flags.isSERIES);
                 raw.flags.isHERMES = 1;
             elseif MRSCont.flags.isHERCULES
-                raw         = io_loadspec_sdat(MRSCont.files{metab_ll,kk},4);
+                raw         = io_loadspec_sdat(MRSCont.files{metab_ll,kk},4,MRSCont.flags.isSERIES);
                 raw.flags.isHERCULES = 1;
             end
             MRSCont.raw{metab_ll,kk}      = raw;
@@ -89,17 +89,17 @@ for kk = 1:MRSCont.nDatasets(1)
             if MRSCont.flags.hasMM %re_mm
                 temp_ll = MRSCont.opts.MultipleSpectra.mm(ll);
                 if MRSCont.flags.isUnEdited %re_mm                    
-                    raw_mm = io_loadspec_sdat(MRSCont.files_mm{temp_ll,kk},1); %re_mm
+                    raw_mm = io_loadspec_sdat(MRSCont.files_mm{temp_ll,kk},1,MRSCont.flags.isSERIES); %re_mm
                     [raw_mm] = op_rmempty(raw_mm); %re_mm
                     raw_mm.flags.isUnEdited = 1;
                 elseif MRSCont.flags.isMEGA %re_mm
-                    raw_mm = io_loadspec_sdat(MRSCont.files_mm{temp_ll,kk},2); %re_mm
+                    raw_mm = io_loadspec_sdat(MRSCont.files_mm{temp_ll,kk},2,MRSCont.flags.isSERIES); %re_mm
                     raw_mm.flags.isMEGA = 1;
                 elseif MRSCont.flags.isHERMES%re_mm
-                    raw_mm = io_loadspec_sdat(MRSCont.files_mm{temp_ll,kk},1); %re_mm
+                    raw_mm = io_loadspec_sdat(MRSCont.files_mm{temp_ll,kk},1,MRSCont.flags.isSERIES); %re_mm
                     raw_mm.flags.isHERMES = 1;
                 elseif MRSCont.flags.isHERCULES %re_mm
-                    raw_mm = io_loadspec_sdat(MRSCont.files_mm{temp_ll,kk},1); %re_mm
+                    raw_mm = io_loadspec_sdat(MRSCont.files_mm{temp_ll,kk},1,MRSCont.flags.isSERIES); %re_mm
                     raw_mm.flags.isHERCULES = 1;
                 end
                 MRSCont.raw_mm{temp_ll,kk}  = raw_mm;
@@ -109,19 +109,19 @@ for kk = 1:MRSCont.nDatasets(1)
             if MRSCont.flags.hasRef
                 ref_ll = MRSCont.opts.MultipleSpectra.ref(ll);
                 if MRSCont.flags.isUnEdited                    
-                    raw_ref = io_loadspec_sdat(MRSCont.files_ref{ref_ll,kk},1);
+                    raw_ref = io_loadspec_sdat(MRSCont.files_ref{ref_ll,kk},1,MRSCont.flags.isSERIES);
                     raw_ref = op_combine_water_subspecs(raw_ref,0);
                     raw_ref.flags.isUnEdited = 1;
                 elseif MRSCont.flags.isMEGA
-                    raw_ref = io_loadspec_sdat(MRSCont.files_ref{ref_ll,kk},2);
+                    raw_ref = io_loadspec_sdat(MRSCont.files_ref{ref_ll,kk},2,MRSCont.flags.isSERIES);
                     raw_ref = op_combine_water_subspecs(raw_ref,0);
                     raw_ref.flags.isMEGA = 1;
                 elseif MRSCont.flags.isHERMES
-                    raw_ref = io_loadspec_sdat(MRSCont.files_ref{ref_ll,kk},1);
+                    raw_ref = io_loadspec_sdat(MRSCont.files_ref{ref_ll,kk},1,MRSCont.flags.isSERIES);
                     raw_ref = op_combine_water_subspecs(raw_ref,0);
                     raw_ref.flags.isHERMES = 1;
                  elseif MRSCont.flags.isHERCULES
-                    raw_ref = io_loadspec_sdat(MRSCont.files_ref{ref_ll,kk},1);
+                    raw_ref = io_loadspec_sdat(MRSCont.files_ref{ref_ll,kk},1,MRSCont.flags.isSERIES);
                     raw_ref = op_combine_water_subspecs(raw_ref,0);
                     raw_ref.flags.isHERCULES = 1;
                 end
@@ -129,7 +129,7 @@ for kk = 1:MRSCont.nDatasets(1)
             end
             if MRSCont.flags.hasWater
                 w_ll = MRSCont.opts.MultipleSpectra.w(ll);
-                raw_w   = io_loadspec_sdat(MRSCont.files_w{w_ll,kk},1);
+                raw_w   = io_loadspec_sdat(MRSCont.files_w{w_ll,kk},1,MRSCont.flags.isSERIES);
                 raw_w = op_combine_water_subspecs(raw_w,0);
                 raw_w.flags.isUnEdited = 1;
                 MRSCont.raw_w{w_ll,kk}    = raw_w;
@@ -139,19 +139,19 @@ for kk = 1:MRSCont.nDatasets(1)
             if MRSCont.flags.hasMMRef
                 temp_ll = MRSCont.opts.MultipleSpectra.mm_ref(ll);
                 if MRSCont.flags.isUnEdited
-                    raw_mm_ref = io_loadspec_sdat(MRSCont.files_mm_ref{temp_ll,kk},1);
+                    raw_mm_ref = io_loadspec_sdat(MRSCont.files_mm_ref{temp_ll,kk},1,MRSCont.flags.isSERIES);
                     raw_mm_ref = op_combine_water_subspecs(raw_mm_ref,0);
                     raw_mm_ref.flags.isUnEdited = 1;
                 elseif MRSCont.flags.isMEGA
-                    raw_mm_ref = io_loadspec_sdat(MRSCont.files_mm_ref{temp_ll,kk},2);
+                    raw_mm_ref = io_loadspec_sdat(MRSCont.files_mm_ref{temp_ll,kk},2,MRSCont.flags.isSERIES);
                     raw_mm_ref = op_combine_water_subspecs(raw_mm_ref,0);
                     raw_mm_ref.flags.isMEGA = 1;
                 elseif MRSCont.flags.isHERMES
-                    raw_mm_ref = io_loadspec_sdat(MRSCont.files_mm_ref{temp_ll,kk},1);
+                    raw_mm_ref = io_loadspec_sdat(MRSCont.files_mm_ref{temp_ll,kk},1,MRSCont.flags.isSERIES);
                     raw_mm_ref = op_combine_water_subspecs(raw_mm_ref,0);
                     raw_mm_ref.flags.isHERMES = 1;
                  elseif MRSCont.flags.isHERCULES
-                    raw_mm_ref = io_loadspec_sdat(MRSCont.files_mm_ref{temp_ll,kk},1);
+                    raw_mm_ref = io_loadspec_sdat(MRSCont.files_mm_ref{temp_ll,kk},1,MRSCont.flags.isSERIES);
                     raw_mm_ref = op_combine_water_subspecs(raw_mm_ref,0);
                     raw_mm_ref.flags.isHERCULES = 1;
                 end

--- a/settings/OspreySettings.m
+++ b/settings/OspreySettings.m
@@ -28,6 +28,7 @@ MRSCont.flags.isHERCULES            = 0;
 MRSCont.flags.isPRIAM               = 0;
 MRSCont.flags.isMRSI                = 0;
 MRSCont.flags.isSPECIAL             = 0;
+MRSCont.flags.isSERIES              = 0;
 MRSCont.flags.addImages             = 0;
 MRSCont.flags.reordered             = 0;
 MRSCont.opts.savePDF                = 0;


### PR DESCRIPTION
This crash is related to the the spar loader and how it recognizes whether a 'Series' scan has been acquired. It falsely identified the MEGA data as a series data resulting in a crash.

Added a new flag to indicate series data in the container.