### PR TITLE
[FEATURE] - Update Segmentation for BIDS and Overlay - OspreySeg - Helge Zoellner

### DIFF
--- a/libraries/mat2im/license.txt
+++ b/libraries/mat2im/license.txt
@@ -1,0 +1,24 @@
+Copyright (c) 2010, Rob Campbell
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/libraries/mat2im/mat2im.m
+++ b/libraries/mat2im/mat2im.m
@@ -1,0 +1,94 @@
+function im=mat2im(mat,cmap,limits)
+% mat2im - convert to rgb image
+%
+% function im=mat2im(mat,cmap,maxVal)
+%
+% PURPOSE
+% Uses vectorized code to convert matrix "mat" to an m-by-n-by-3
+% image matrix which can be handled by the Mathworks image-processing
+% functions. The the image is created using a specified color-map
+% and, optionally, a specified maximum value. Note that it discards
+% negative values!
+%
+% INPUTS
+% mat     - an m-by-n matrix  
+% cmap    - an m-by-3 color-map matrix. e.g. hot(100). If the colormap has 
+%           few rows (e.g. less than 20 or so) then the image will appear 
+%           contour-like.
+% limits  - by default the image is normalised to it's max and min values
+%           so as to use the full dynamic range of the
+%           colormap. Alternatively, it may be normalised to between
+%           limits(1) and limits(2). Nan values in limits are ignored. So
+%           to clip the max alone you would do, for example, [nan, 2]
+%          
+%
+% OUTPUTS
+% im - an m-by-n-by-3 image matrix  
+%
+%
+% Example 1 - combine multiple color maps on one figure 
+% clf, colormap jet, r=rand(40);
+% subplot(1,3,1),imagesc(r), axis equal off , title('jet')
+% subplot(1,3,2),imshow(mat2im(r,hot(100))) , title('hot')
+% subplot(1,3,3),imshow(mat2im(r,summer(100))), title('summer')
+% colormap winter %changes colormap in only the first panel
+%
+% Example 2 - clipping
+% p=peaks(128); J=jet(100);
+% subplot(2,2,1), imshow(mat2im(p,J)); title('Unclipped')
+% subplot(2,2,2), imshow(mat2im(p,J,[0,nan])); title('Remove pixels <0')
+% subplot(2,2,3), imshow(mat2im(p,J,[nan,0])); title('Remove pixels >0')
+% subplot(2,2,4), imshow(mat2im(p,J,[-1,3])); title('Plot narrow pixel range')
+%
+% Rob Campbell - April 2009
+%
+% See Also: ind2rgb, imadjust
+
+
+%Check input arguments
+error(nargchk(2,3,nargin));
+
+if ~isa(mat, 'double')
+    mat = double(mat)+1;    % Switch to one based indexing
+end
+
+if ~isnumeric(cmap)
+    error('cmap must be a colormap, such as jet(100)')
+end
+
+
+%Clip if desired
+L=length(cmap);
+if nargin==3 && length(limits)==1
+    warning('limits should be vector of length of 2. Assuming a max value was specified.')
+    limits=[nan,limits];
+end
+
+
+if nargin==3
+    minVal=limits(1);
+    if isnan(minVal), minVal=min(mat(:)); end    
+    mat(mat<minVal)=minVal;
+    
+    maxVal=limits(2);
+    if isnan(maxVal), maxVal=max(mat(:)); end
+    mat(mat>maxVal)=maxVal;        
+else
+minVal=min(mat(:));
+maxVal=max(mat(:));
+end
+
+
+%Normalise 
+mat=mat-minVal;
+mat=(mat/(maxVal-minVal))*(L-1);
+mat=mat+1;
+
+
+%convert to indecies 
+mat=round(mat); 
+
+
+%Vectorised way of making the image matrix 
+im=reshape(cmap(mat(:),:),[size(mat),3]);
+

--- a/plot/osp_plotVoxelOverlap.m
+++ b/plot/osp_plotVoxelOverlap.m
@@ -1,0 +1,141 @@
+function out = osp_plotVoxelOverlap(MRSCont,voxelCenter)
+%% out = osp_plotVoxelOverlap(MRSCont)
+%   Creates a figure showing overlap of all MRS voxels in spm152 space
+%
+%   USAGE:
+%       out = osp_plotVoxelOverlap(MRSCont)
+%
+%   OUTPUTS:
+%       out     = MATLAB figure handle
+%
+%   INPUTS:
+%       MRSCont  = Osprey data container.
+%       voxelCenter = center coordinates to be used for the three plane
+%       image (optinal). If no coordinates are supplied the center of mass
+%       of all voxels is calculated to identify the voxel center.
+%
+%   AUTHOR:
+%       Helge Zöllner (Johns Hopkins University, 2022-07-15)
+%       hzoelln2@jhmi.edu
+%
+%   HISTORY:
+%       2022-07-15: First version of the code.
+%
+% For the SPM152 template we are using the MRIcroGL spm152 template.
+
+% Check that OspreySeg has been run before
+if ~MRSCont.flags.didSeg
+    error('Trying to plot voxel overlap, but data has not been processed yet. Run OspreySeg first.')
+end
+
+%%% 1. PARSE INPUT ARGUMENTS %%%
+% Fall back to defaults if not provided
+
+if nargin<1
+    error('ERROR: no input Osprey container specified.  Aborting!!');
+end
+if nargin<2
+    voxelCenter =[];
+end
+
+%%% 2. LOAD DATA TO PLOT %%%
+if ~(isfield(MRSCont.flags,'addImages') && (MRSCont.flags.addImages == 1))
+    % Load spm152 template and mask overlap
+     template = which('osprey/libraries/MRIcroGL/templates/spm152.nii');
+    [~,filename_image,fileext_image]   = fileparts(template);
+    [~,filename_mask,~]   = fileparts(MRSCont.seg.overlapfile);
+
+    if ~exist(MRSCont.seg.overlapfile,'file')
+        gunzip([MRSCont.seg.overlapfile, '.gz']);
+    end
+
+    %%% 3. SET UP THREE PLANE IMAGE %%%
+    [three_plane_img,three_plane_overlay,vox_t_size] = osp_extract_three_plane_image_overlay(template, MRSCont.seg.overlapfile,voxelCenter,90);
+
+    %%% 4. SET UP FIGURE LAYOUT %%%
+    % Generate a new figure and keep the handle memorized
+
+    if ~MRSCont.flags.didSeg
+        if exist([MRSCont.coreg.vol_mask{kk}.fname, '.gz'],'file')
+            delete(MRSCont.coreg.vol_mask{kk}.fname);
+        end
+        if exist([MRSCont.coreg.vol_image{kk}.fname, '.gz'],'file')
+            delete(MRSCont.coreg.vol_image{kk}.fname);
+        end
+    end
+else
+    [~,filename_voxel,fileext_voxel]   = fileparts(MRSCont.files{kk});
+    [~,filename_image,fileext_image]   = fileparts(MRSCont.coreg.vol_image{kk}.fname);
+    three_plane_img = MRSCont.coreg.three_plane_img{kk};
+end
+
+
+if ~MRSCont.flags.isGUI
+    out = figure('Visible','on');
+    set(gcf, 'Color', 'w');
+else
+    out = figure('Visible','off');
+end
+
+bar = repmat(linspace(0,1,size(three_plane_overlay,2)),[15 1]);
+three_plane_overlay = vertcat(bar,three_plane_overlay);
+three_plane_img = vertcat(0.7*ones(size(bar)),three_plane_img);
+rgb = mat2im(three_plane_overlay,jet(1000));
+for col = 1 : 3
+    temp = rgb(:,:,col);
+    temp(three_plane_overlay==0)=0;
+    rgb(:,:,col) = temp;
+end
+ha= imshow(rgb);
+axis equal;
+axis tight;
+axis off;
+hold on;
+hb = imshow(mat2gray(three_plane_img));
+% caxis([0 mean(three_plane_img(three_plane_img > 0.01)) + 3*std(three_plane_img(three_plane_img > 0.01))]);
+% colormap('gray');
+AlphaChannel = three_plane_overlay;
+
+set(hb,'AlphaData',1-AlphaChannel);
+
+text(floor(vox_t_size/4), size(three_plane_img,1)-15, 'L', 'Color', MRSCont.colormap.Background, 'FontSize', 14, 'HorizontalAlignment', 'center');
+text(floor(vox_t_size), size(three_plane_img,1)-15, 'R', 'Color', MRSCont.colormap.Background, 'FontSize', 14, 'HorizontalAlignment', 'center');
+text(1, 25+15, 'Overlap [%]', 'Color', MRSCont.colormap.Background, 'FontSize', 16, 'HorizontalAlignment', 'left');
+text(1, 8+15, '0', 'Color', MRSCont.colormap.Background, 'FontSize', 16, 'HorizontalAlignment', 'left');
+text(size(three_plane_img,2)*1/4, 8+15, '25', 'Color', MRSCont.colormap.Background, 'FontSize', 16, 'HorizontalAlignment', 'center');
+text(size(three_plane_img,2)*2/4, 8+15, '50', 'Color', MRSCont.colormap.Background, 'FontSize', 16, 'HorizontalAlignment', 'center');
+text(size(three_plane_img,2)*3/4, 8+15, '75', 'Color', MRSCont.colormap.Background, 'FontSize', 16, 'HorizontalAlignment', 'center');
+text(size(three_plane_img,2)-25, 8+15, '100', 'Color', MRSCont.colormap.Background, 'FontSize', 16, 'HorizontalAlignment', 'left');
+
+
+if ~(isfield(MRSCont.flags,'isPRIAM') && (MRSCont.flags.isPRIAM == 1))
+    titleStr = sprintf(['Voxel Consistency:\n ' filename_mask ' & SPM 152 template']);
+else
+    titleStr = sprintf(['Coregistration:\n ' filename_voxel fileext_voxel ' & '  filename_image fileext_image '\n Voxel ' num2str(VoxelIndex)]);      
+end
+
+if ~MRSCont.flags.isGUI
+        title(titleStr, 'Interpreter', 'none','FontSize', 16);
+else
+    title(titleStr, 'Interpreter', 'none','FontSize', 16,'Color', MRSCont.colormap.Foreground);
+end
+
+sz = get(gcf, 'Position');
+set(gcf,'Position',[sz(1) sz(2) 850 400])
+
+%%% 5. ADD OSPREY LOGO %%%
+if ~MRSCont.flags.isGUI
+    [I, map] = imread('osprey.gif','gif');
+    axes(out, 'Position', [0, 0.85, 0.15, 0.15*11.63/14.22]);
+    imshow(I, map);
+    axis off;
+end
+
+if exist(MRSCont.seg.overlapfile,'file')
+    gzip(MRSCont.seg.overlapfile);
+    delete(MRSCont.seg.overlapfile);
+end
+
+end
+
+   

--- a/seg/osp_extract_three_plane_image_overlay.m
+++ b/seg/osp_extract_three_plane_image_overlay.m
@@ -1,0 +1,76 @@
+% osp_extract_three_plane_image_overlay.m
+% Helge Zoellner, Johns Hopkins University 2021.
+%
+% USAGE:
+% [three_plane_image] = osp_extract_three_plane_image(ImageFile, MaskFile);
+%
+% DESCRIPTION:
+% Creates a SPM volume containing a voxel mask with the same dimensions
+% as the SPM volume containing a structural image. The voxel mask will be
+% created with the geometry information stored in the FID-A structure "in".
+% This routine works for the GE P data type.
+
+% INPUTS:
+% ImageFile   = Path to Image File (NifTI).
+% MaskFile    = Path to Mask Volume (NifTI).
+% VoxelIndex  = Voxel index for PRIAM
+%
+% OUTPUTS:
+% three_plane_img  = three plane image for plots and GUI.
+
+
+function [three_plane_img, three_plane_overlay,size_vox_t] = osp_extract_three_plane_image_overlay(ImageFile, MaskFile,voxel_ctr,T1_max);
+%%% 1. LOAD IMAGE AND MASK VOLUME %%%
+
+    Vimage=spm_vol(ImageFile);
+    Vmask=spm_vol(MaskFile);   
+
+    [mask,~] = spm_read_vols(Vmask);
+    if isempty(voxel_ctr)
+        center = regionprops3(logical(mask),'Centroid');
+        center = round(center{1,:});
+        center = [center , 1];
+        centerWorldSpace = Vmask.mat*center';
+    else
+        centerWorldSpace=voxel_ctr;
+    end
+    
+
+    %%% 2. SET UP THREE PLANE IMAGE %%%
+    % Generate three plane image for the output
+    % Transform structural image and co-registered voxel mask from voxel to
+    % world space for output (MM: 180221)
+
+    [img_t,img_c,img_s] = voxel2world_space(Vimage,centerWorldSpace(1:3));
+    [mask_t,mask_c,mask_s] = voxel2world_space(Vmask,centerWorldSpace(1:3));
+
+    img_t = flipud(img_t/T1_max);
+    img_c = flipud(img_c/T1_max);
+    img_s = flipud(img_s/T1_max);
+
+
+    size_max = max([max(size(img_t)) max(size(img_c)) max(size(img_s))]);
+    three_plane_img = zeros([size_max 3*size_max]);
+    three_plane_img(:,1:size_max)              = image_center(img_t, size_max);
+    three_plane_img(:,size_max+(1:size_max))   = image_center(img_s, size_max);
+    three_plane_img(:,size_max*2+(1:size_max)) = image_center(img_c, size_max);
+
+
+    mask_t = flipud(mask_t);
+    mask_c = flipud(mask_c);
+    mask_s = flipud(mask_s);
+
+%     mask_t(mask_t==0) = nan;
+%     mask_c(mask_c==0) = nan;
+%     mask_s(mask_s==0) = nan;
+
+
+
+
+    size_max = max([max(size(mask_t)) max(size(mask_c)) max(size(mask_s))]);
+    three_plane_overlay = zeros([size_max 3*size_max]);
+    three_plane_overlay(:,1:size_max)              = image_center(mask_t, size_max);
+    three_plane_overlay(:,size_max+(1:size_max))   = image_center(mask_s, size_max);
+    three_plane_overlay(:,size_max*2+(1:size_max)) = image_center(mask_c, size_max);
+    size_vox_t = size(mask_t,2);
+end

--- a/utilities/osp_RemovePreFix.m
+++ b/utilities/osp_RemovePreFix.m
@@ -1,0 +1,17 @@
+function[OutName] = osp_RemovePreFix(Name)
+%% function[OutName] = osp_RemovePreFix(Name)
+% Function to remove prefix from filenames while respecting key-value pairs
+% as defined in BIDs specification.
+% i.e.  osp_RemovePreFix('sub-001_MyDataSet_acq-press_act') = MyDataSet_acq-press
+% while osp_RemovePreFix('sub-001_MyDataSet_acq-press') = sub-001_MyDataSet_acq-press
+
+[~,Name,~] = fileparts(Name); %Remove lingering paths and extensions
+
+SplitName = strsplit(Name,'_'); %Separate out by underscores
+
+% if isempty(strfind(SplitName{1},'-')) % If final underscore is not a key-value pair
+    SplitName = SplitName(2:end); % Remove Pre
+% end
+OutName = strjoin(SplitName,'_');
+
+end


### PR DESCRIPTION
- Changed the segmentation output to match BIDS
- Export Deformation Field during the segmentation to calculate SPM152 overlap masks
- Updated OspreySeg to calculate voxel masks in SPM152 space. To make this work on an older analysis you have to remove the old SPM outputs from your folder.
- New function to generate a voxel consistency figure. It calculates the center of mass to find the voxel center. However, the user can also input the voxel center as an argument.