### PR TITLE
[BUG FIX] - fieldtrip interferes with MATLAB finv - regression_line_c…

### DIFF
--- a/libraries/regression_line_ci.m
+++ b/libraries/regression_line_ci.m
@@ -40,6 +40,12 @@ SSX = (N-1)*var(x);
 SE_Y = SE_y_cond_x*(ones(size(X))*(1/N + (mean(x)^2)/SSX) + (X.^2 - 2*mean(x)*X)/SSX);
 
 
+finv_path  = which('finv.m');
+if contains(finv_path,'fieldtrip')
+    [finv_path,~,~]=fileparts(finv_path);
+    rmpath(finv_path);
+end
+
 Yoff = (2*finv(1-alpha,2,N-2)*SE_Y).^0.5;
 
 


### PR DESCRIPTION
…i - Koen Cuypers

- Once again fieldtrip is using MATLAB internal function names that break Osprey/MATLAB. Added a conditional statement to remove the fieldtrip function.

- The user could also avoid this by including SPM12 without sufolders