### PR TITLE
Fixes #498

### DIFF
--- a/libraries/FID-A/inputOutput/io_loadspec_twix.m
+++ b/libraries/FID-A/inputOutput/io_loadspec_twix.m
@@ -79,7 +79,8 @@ isMinn=~isempty(strfind(sequence,'eja_svs_')); %Is this one of Eddie Auerbach's 
 isSiemens=(~isempty(strfind(sequence,'svs_se')) ||... %Is this the Siemens PRESS seqeunce?
             ~isempty(strfind(sequence,'svs_st'))) && ... % or the Siemens STEAM sequence?
             isempty(strfind(sequence,'eja_svs'));    %And make sure it's not 'eja_svs_steam'.
-isUniversal = ~isempty(strfind(sequence,'univ')); %Is JHU universal editing sequence
+isUniversal = ~isempty(strfind(sequence,'univ')) ||... %Is JHU universal editing sequence
+              ~isempty(strfind(sequence,'smm_svs_herc')); % Is Pavi's HERCULES sequence
 isDondersMRSfMRI = contains(sequence,'moco_nav_set'); %Is combined fMRI-MRS sequence implemented at Donders Institute NL
 isConnectom = contains(twix_obj.hdr.Dicom.ManufacturersModelName,'Connectom'); %Is from Connectom scanner (Apparently svs_se Dims are not as expected for vd)
 

--- a/process/osp_combineCoils.m
+++ b/process/osp_combineCoils.m
@@ -187,7 +187,7 @@ else
             end
             MRSCont.raw{metab_ll,kk}     = raw_comb;
             MRSCont.raw_ref{ref_ll,kk} = raw_ref_comb;
-            if MRSCont.raw_ref{ref_ll,kk}.subspecs > 1 && ~isSpecial && (length(size(MRSCont.raw_ref{ref_ll,kk}.fids)) > 2)
+            if MRSCont.raw_ref{ref_ll,kk}.subspecs > 1 && ~isSpecial && (length(size(MRSCont.raw_ref{ref_ll,kk}.fids)) >= 2)
                 MRSCont.raw_ref{ll,kk} = op_combine_water_subspecs(MRSCont.raw_ref{ll,kk},0);
             else
                 % Maintain spatial sub-spectra for SPECIAL-localized data.
@@ -238,7 +238,7 @@ else
             end
             MRSCont.raw{metab_ll,kk}     = raw_comb;
             MRSCont.raw_ref{ref_ll,kk} = raw_ref_comb;
-            if MRSCont.raw_ref{ref_ll,kk}.subspecs > 1 && ~isSpecial && (length(size(MRSCont.raw_ref{ref_ll,kk}.fids)) > 2)
+            if MRSCont.raw_ref{ref_ll,kk}.subspecs > 1 && ~isSpecial && (length(size(MRSCont.raw_ref{ref_ll,kk}.fids)) >= 2)
                 MRSCont.raw_ref{ll,kk} = op_combine_water_subspecs(MRSCont.raw_ref{ll,kk},0);
             else
                 % Maintain spatial sub-spectra for SPECIAL-localized data.


### PR DESCRIPTION
Now catches Pavi's sequence as Siemens
Fix bug with reference sub-spectra dimensions