### PR TITLE
[BUG FIX] - Segmentation fails for DCM spec files - OspreyCoreg Ospre…

### DIFF
--- a/coreg/OspreyCoreg.m
+++ b/coreg/OspreyCoreg.m
@@ -46,7 +46,19 @@ if MRSCont.nDatasets(1) > 1
     specFile2 = MRSCont.files{2};
     [~, SpecName, ~]  = fileparts(specFile);
     [~, SpecName2, ~]  = fileparts(specFile2);
-    SameName = strcmp(SpecName,SpecName2);
+    if ~isempty(SpecName) && ~isempty(SpecName2)
+        SameName = strcmp(SpecName,SpecName2);
+    else
+        [DirName, ~, ~]  = fileparts(specFile);
+        [DirName2, ~, ~]  = fileparts(specFile2);
+        SepFiles =  split(DirName, filesep);
+        SepFiles(strcmp(SepFiles,''))=[];
+        DirName = SepFiles{end};
+        SepFiles =  split(DirName2, filesep);
+        SepFiles(strcmp(SepFiles,''))=[];
+        DirName2 = SepFiles{end};
+        SameName = strcmp(DirName,DirName2);
+    end
 end
 MRSCont.coreg.SameName = SameName;
 
@@ -69,17 +81,25 @@ for kk = 1:MRSCont.nDatasets(1)
         
         if SameName
             [PreFix] = osp_generate_SubjectAndSessionPrefix(MRSCont.files{kk},kk);
+            PreFix = [PreFix '_'];
         else
             PreFix = '';
         end
 
         % Get the input file name
-        [~,filename,~]   = fileparts(MRSCont.files{kk});
+        if ~exist('DirName','var')
+            [~,filename,~]   = fileparts(MRSCont.files{kk});
+        else
+            [dirname,~,~]   = fileparts(MRSCont.files{kk});
+            SepFiles =  split(dirname, filesep);
+            SepFiles(strcmp(SepFiles,''))=[];
+            filename = SepFiles{end};
+        end
         % Get the nii file name
         [~,~,T1ext]   = fileparts(MRSCont.files_nii{kk});
         
         %<source_entities>[_space-<space>][_res-<label>][_den-<label>][_label-<label>][_desc-<label>]_mask.nii.gz
-        saveName = [PreFix '_' filename '_space-scanner']; %CWDJ Check space.
+        saveName = [PreFix filename '_space-scanner']; %CWDJ Check space.
         
         % Generate file name for the voxel mask NIfTI file to be saved under
         maskFile            = fullfile(saveDestination, [saveName '_mask.nii']);

--- a/seg/OspreySeg.m
+++ b/seg/OspreySeg.m
@@ -290,8 +290,15 @@ for kk = 1:MRSCont.nDatasets(1)
 
             % Get the input file name
             [~,filename,~]   = fileparts(MRSCont.files{kk});
+            if isempty(filename)
+                [dirname,~,~]   = fileparts(MRSCont.files{kk});
+                SepFiles =  split(dirname, filesep);
+                SepFiles(strcmp(SepFiles,''))=[];
+                filename = SepFiles{end};
+            end
             if MRSCont.coreg.SameName
                 [PreFixMask] = osp_generate_SubjectAndSessionPrefix(MRSCont.files{kk},kk);
+                PreFix = [PreFix '_'];
             else
                 PreFixMask = '';
             end
@@ -299,7 +306,7 @@ for kk = 1:MRSCont.nDatasets(1)
             % <source_entities>[_space-<space>][_res-<label>][_label-<label>][_desc-<label>]_probseg.nii.gz
             % e.g.
             % sub-01_acq-press_space-individual_desc-dlpfc_label-GM_probseg.nii.gz
-            saveName = [PreFixMask '_' filename '_space-scanner']; %CWDJ Check space.
+            saveName = [PreFixMask filename '_space-scanner']; %CWDJ Check space.
 
             %Add voxel number for DualVoxel
             if ~(isfield(MRSCont.flags,'isPRIAM') && (MRSCont.flags.isPRIAM == 1))

--- a/utilities/osp_generate_SubjectAndSessionPrefix.m
+++ b/utilities/osp_generate_SubjectAndSessionPrefix.m
@@ -23,13 +23,16 @@ if ~contains(Name,{'ses'},'IgnoreCase',true)
 else
     SepFiles =  split(Name, filesep);
     SepFiles(strcmp(SepFiles,''))=[];
-    ind = find(contains(ses,'ses'));
+    ind = find(contains(SepFiles,'ses'));
+    if length(ind) > 1
+        ind = ind(1);
+    end
     goUpNTimes = length(SepFiles) - ind;
     tempDir = fullfile(Name,repmat(['..' filesep],[1 goUpNTimes]));
     tempDir = dir(tempDir);
     tempDir = tempDir(1).folder;
     SepFiles =  split(tempDir, filesep);
-    PreFix = [PreFix '_' SepFiles{end-1}];
+    PreFix = [PreFix '_' SepFiles{end}];
 end
 
 end


### PR DESCRIPTION
…ySeg - Stella Hadfield Elliot

This bug was related to the fact that DCM files have no filename during the fileparts generation of the file input. Therefore, they were always flagged as SameName files. However, without a filename the OspreySeg output resulted in similar file names for all datasets.

This has now been fixed for OspreyCoreg and OspreySeg.