### PR TITLE
[BUG FIX] - Philips loader crashes on LINUX system - philipsLoad.m - …

### DIFF
--- a/libraries/FID-A/inputOutput/philipsLoad.m
+++ b/libraries/FID-A/inputOutput/philipsLoad.m
@@ -20,10 +20,13 @@ function [data, header] = philipsLoad(filename)
 
 % Get the .spar filename
 sparname = [filename(1:(end-4)) 'spar'];
-
 % Populate the header information from the SPAR file
 % Look for regular expression separated by a colon
 fid_spar = fopen(sparname);
+if fid_spar == -1
+    sparname = [filename(1:(end-4)) 'SPAR']; %This seems to be a problem for some Linux based systems
+    fid_spar = fopen(sparname);
+end
 while ~feof(fid_spar)
     tline = fgets(fid_spar); % get first line
     [tokens,matches] = regexp(tline,'([\w\[\].]*)\s*:\s*([-\w\s.\"\\:\.]*)','tokens','match');


### PR DESCRIPTION
…Koen Cuypers

This bug was related to the automatic replacement  of the file ending to 'spar'. For some Linux-based systems this lead to the file not being found and subsequently opened. Fixed with an additional test/replacement with capital letters.