### PR TITLE
BUG OspreyJob .m defaults

### DIFF
--- a/job/OspreyJob.m
+++ b/job/OspreyJob.m
@@ -454,6 +454,12 @@ else if ~isfield(MRSCont.opts.SubSpecAlignment, 'mets')
     end
 end
 
+if isfield(MRSCont.opts,'exportParams')
+    fprintf('Spectral fitting parameters will not be saved (default). Please indicate otherwise in the csv-file or the GUI \n');
+    MRSCont.opts.exportParams.flag = 0;
+    MRSCont.opts.exportParams.path = {};
+end
+
 
 %%% 4. SAVE SETTINGS & STAT FILE INTO MRSCONT  %%%
 % Parse the sequence type entry


### PR DESCRIPTION
export parameters were not correctly set if .m file is used as input jobfile. Again caught by CI