### PR TITLE
[BUG FIX] - Unrecognized field in basis set - OspreyFit - Mingrun Shi

### DIFF
--- a/GUI/osp_iniFitWindow.m
+++ b/GUI/osp_iniFitWindow.m
@@ -310,7 +310,7 @@ for t = 1 : gui.fit.Number %Loop over fits
             waterFitRangeString = ['Fitting range: ' num2str(MRSCont.opts.fit.rangeWater(1)) ' to ' num2str(MRSCont.opts.fit.rangeWater(2)) ' ppm'];
             % Where are the metabolite names stored?
             if strcmp(gui.fit.Style, 'ref') || strcmp(gui.fit.Style, 'w')
-                basisSetNames = MRSCont.fit.resBasisSet.(gui.fit.Style).(['np_sw_' num2str(round(MRSCont.processed.metab{1}.sz(1))) '_' num2str(round(MRSCont.processed.metab{1}.spectralwidth))]){1,1}.name;
+                basisSetNames = MRSCont.fit.resBasisSet.(gui.fit.Style).(['np_sw_' num2str(round(MRSCont.processed.(gui.fit.Style){1}.sz(1))) '_' num2str(round(MRSCont.processed.(gui.fit.Style){1}.spectralwidth))]){1,1}.name;
             else if strcmp(gui.fit.Style, 'conc')
                     basisSetNames = MRSCont.fit.resBasisSet.(gui.fit.Style).(['np_sw_' num2str(round(MRSCont.processed.metab{1}.sz(1))) '_' num2str(round(MRSCont.processed.metab{1}.spectralwidth))]){1,1}.name;
                 else

--- a/GUI/osp_updateFitWindow.m
+++ b/GUI/osp_updateFitWindow.m
@@ -78,7 +78,7 @@ function osp_updateFitWindow(gui)
                 waterFitRangeString = ['Fitting range: ' num2str(MRSCont.opts.fit.rangeWater(1)) ' to ' num2str(MRSCont.opts.fit.rangeWater(2)) ' ppm'];
                 % Where are the metabolite names stored?
                 if strcmp(gui.fit.Style, 'ref') || strcmp(gui.fit.Style, 'w')
-                    basisSet = MRSCont.fit.resBasisSet.(gui.fit.Style).(['np_sw_' num2str(round(MRSCont.processed.metab{gui.controls.Selected}.sz(1))) '_' num2str(round(MRSCont.processed.metab{gui.controls.Selected}.spectralwidth))]){1};
+                    basisSet = MRSCont.fit.resBasisSet.(gui.fit.Style).(['np_sw_' num2str(round(MRSCont.processed.(gui.fit.Style){gui.controls.Selected}.sz(1))) '_' num2str(round(MRSCont.processed.(gui.fit.Style){gui.controls.Selected}.spectralwidth))]){1};
                     basisSetNames = basisSet.name;
                 else if strcmp(gui.fit.Style, 'conc')
                         basisSet = MRSCont.fit.resBasisSet.(gui.fit.Style).(['np_sw_' num2str(round(MRSCont.processed.metab{gui.controls.Selected}.sz(1))) '_' num2str(round(MRSCont.processed.metab{gui.controls.Selected}.spectralwidth))]){basis,1};

--- a/fit/code/OspreyFit.m
+++ b/fit/code/OspreyFit.m
@@ -133,16 +133,9 @@ if strcmpi(MRSCont.opts.fit.method, 'Osprey')
         FitNames = fieldnames(MRSCont.fit.resBasisSet);
         NoFit = length(fieldnames(MRSCont.fit.resBasisSet));
         for sf = 1 : NoFit
-            if iscell(MRSCont.fit.resBasisSet.(FitNames{sf}))
-                MRSCont.fit.resBasisSet.(FitNames{sf}) = MRSCont.fit.resBasisSet.(FitNames{sf})(:,MRSCont.info.metab.unique_ndatapoint_spectralwidth_ind,:);
-                for combs = 1 : length(MRSCont.info.metab.unique_ndatapoint_spectralwidth_ind)
-                    resBasisSetNew.(FitNames{sf}).([MRSCont.info.metab.unique_ndatapoint_spectralwidth{combs}]) = MRSCont.fit.resBasisSet.(FitNames{sf})(:,combs,:);
-                end
-            else
-                MRSCont.fit.resBasisSet.(FitNames{sf}).water = MRSCont.fit.resBasisSet.(FitNames{sf}).water(MRSCont.info.(FitNames{sf}).unique_ndatapoint_spectralwidth_ind);
-                for combs = 1 : length(MRSCont.info.(FitNames{sf}).unique_ndatapoint_spectralwidth_ind)
-                    resBasisSetNew.(FitNames{sf}).water.([MRSCont.info.(FitNames{sf}).unique_ndatapoint_spectralwidth{combs}]) = MRSCont.fit.resBasisSet.(FitNames{sf}).water{combs};
-                end
+            MRSCont.fit.resBasisSet.(FitNames{sf}) = MRSCont.fit.resBasisSet.(FitNames{sf})(:,MRSCont.info.(FitNames{sf}).unique_ndatapoint_spectralwidth_ind,:);
+            for combs = 1 : length(MRSCont.info.(FitNames{sf}).unique_ndatapoint_spectralwidth_ind)
+                resBasisSetNew.(FitNames{sf}).([MRSCont.info.(FitNames{sf}).unique_ndatapoint_spectralwidth{combs}]) = MRSCont.fit.resBasisSet.(FitNames{sf})(:,combs,:);
             end
         end
         MRSCont.fit.resBasisSet = resBasisSetNew;


### PR DESCRIPTION
- The field names for the resampled basis set were always parsed from the metabolite file. This has now been fixed during the memory optimization and the GUI calls.