### PR TITLE
[BUG FIX] - relaxation correction for waterScaled/CSFcorrected estima…

### DIFF
--- a/quantify/OspreyQuantify.m
+++ b/quantify/OspreyQuantify.m
@@ -591,13 +591,9 @@ function rawWaterScaled = quantH2O(metsName, amplMets, amplWater, metsTR, waterT
 % Define constants
 PureWaterConc       = 55500;            % mmol/L
 WaterVisibility     = 0.65;             % assuming pure white matter
-metsTE              = metsTE * 1e-3;    % convert to s
-waterTE             = waterTE * 1e-3;   % convert to s
-metsTR              = metsTR * 1e-3;    % convert to s
-waterTR             = waterTR * 1e-3;   % convert to s
+
 
 % Look up relaxation times
-
 switch Bo
     case '3T'
         % 3T Water


### PR DESCRIPTION
…tes - OspreyQuantify -  ZeinabEftekhari

The TE/TR values incorrectly scaled (applying conversion from ms to s twice) for WaterScaled values which changes the subsequent CSF corrected estiamtes as well. Therefore the relaxation correction was not applied correctly.

Estimates for TissueCorrectedEstimates were correct.