### PR TITLE
[BUG FIX] - Error in osp_fit_Quality when using LCModel

### DIFF
--- a/fit/code/osp_fit_Quality.m
+++ b/fit/code/osp_fit_Quality.m
@@ -54,7 +54,9 @@ end
 
 if MRSCont.flags.hasWater
     OrderNames = horzcat(OrderNames, 'w');
-    OrderNamesFit = horzcat(OrderNamesFit, 'w');
+    if ~strcmp(MRSCont.opts.fit.method,'LCModel')
+        OrderNamesFit = horzcat(OrderNamesFit, 'w');
+    end
 end
 
 S = orderfields(MRSCont.fit.results,OrderNamesFit);


### PR DESCRIPTION
-added bug fix suggested by @peter-mri if long and short echo water files are present when Osprey is being used as LCModel wrapper