### PR TITLE
[BUG FIX] - TR parsed wrongly for niimrs

### DIFF
--- a/libraries/FID-A/inputOutput/io_loadspec_niimrs.m
+++ b/libraries/FID-A/inputOutput/io_loadspec_niimrs.m
@@ -510,7 +510,7 @@ end
                 out.extra_names{ex} = ['TR_' num2str(ex)];
                 out.exp_var(ex) = out.tr(ex);
             else
-                out.tr(ex) = out.te(1);
+                out.tr(ex) = out.tr(1);
             end
 
             if isfield(hdr_ext.(['dim_' num2str(dim_number) '_header']), 'InversionTime')


### PR DESCRIPTION
- accidently parsed te instead of tr in the TR field in the struct for series data. Fixed now