### PR TITLE
fix missing DicomHeader.seqorig field in from Siemens Minnesota seqs

### DIFF
--- a/libraries/FID-A/inputOutput/io_loadspec_dicom.m
+++ b/libraries/FID-A/inputOutput/io_loadspec_dicom.m
@@ -31,7 +31,19 @@ filesInFolder = fullfile(folder, {filesInFolder.name});
 % Get the header of the first file to make some decisions.
 DicomHeader = read_dcm_header(filesInFolder{1});
 seqtype = DicomHeader.seqtype;
-seqorig = DicomHeader.seqorig;
+
+if isfield(DicomHeader, 'seqorig')
+    seqorig = DicomHeader.seqorig;
+else
+% deal with missing seqorig field for dicom data load on Siemens Minnesota
+% sequences (Auerbach and Deelchand versions, VB17A & VE11C)    
+    if contains(DicomHeader.sequenceFileName, 'slaser_dkd') %Deelchand/Oz
+        seqorig = 'CMRR';
+    elseif contains(DicomHeader.sequenceFileName, 'eja_svs') %Auerbach/Marjanska
+        seqorig = 'CMRR';
+    end
+end
+
 
 % Extract voxel dimensions
 % If a parameter is set to zero (e.g. if no voxel rotation is


### PR DESCRIPTION
DicomHeader.seqorig is missing in the dicom output of some Minnesota sequences (e.g. semiLASER, Auerbach and Deelchand versions).  Define seqorig based on the sequence name.