### PR TITLE
Automatically recalculate basis spectra in fit_plotBasis

### DIFF
--- a/libraries/FID-A/fitTools/fit_plotBasis.m
+++ b/libraries/FID-A/fitTools/fit_plotBasis.m
@@ -52,6 +52,11 @@ if nargin<8
     end
 end
 
+% Recalcualte spectra if they are not yet included
+if ~isfield(basisSet,'specs')
+    [basisSet]=osp_recalculate_basis_specs(basisSet)
+end
+
 % Generate a new figure and keep the handle memorized
 out = figure;
 % Prepare a couple of useful variables
@@ -64,7 +69,7 @@ end
 if stagFlag
     % Staggered plots will be in all black and separated by the mean of the
     % maximum across all spectra
-    stag = mean(max(real(basisSet.specs(:,:,dim))));
+    stag = mean(max(real(basisSet.specs(basisSet.ppm > ppmmin & basisSet.ppm < ppmmax,:,dim))));
     
     % Loop over all basis functions
     hold on


### PR DESCRIPTION
- added automatic recalculation of the spectra if fit_plotBasis is called
- removed wrongly labeled fid field from Philips 30 ms unedited PRESS  basisset to avoid confusion.