### PR TITLE
[FEATURE] - Support CMRR sequence with integrated water refernece

### DIFF
--- a/plot/osp_plotLoad.m
+++ b/plot/osp_plotLoad.m
@@ -70,7 +70,7 @@ if nargin<11
                         [~,filen,ext] = fileparts(MRSCont.files_mm{ExpIndex,kk});% re_mm
                         figTitle = sprintf(['Load MM data plot: ' filen ext '\n']);% re_mm
                 case 'ref'
-                    if ~(strcmp(MRSCont.datatype,'P') || strcmp(MRSCont.datatype,'DATA'))
+                    if ~(strcmp(MRSCont.datatype,'P') || strcmp(MRSCont.datatype,'DATA') || isempty(MRSCont.files_ref))
                         [~,filen,ext] = fileparts(MRSCont.files_ref{ExpIndex,kk});
                         figTitle = sprintf(['Load water reference data plot: ' filen ext '\n']);
                     else

--- a/process/osp_combineCoils.m
+++ b/process/osp_combineCoils.m
@@ -90,6 +90,7 @@ if nargin<5
                     else
                         cweights_w          = op_getcoilcombos(MRSCont.raw_w_uncomb{w_ll,kk}, 1, 'h');
                     end
+                    cweights_w.ref      = 'raw_w';
                     raw_w_comb          = op_addrcvrs(MRSCont.raw_w_uncomb{w_ll,kk},1,'h',cweights_w);
                     raw_w_comb.flags.isUnEdited = 1;
                     MRSCont.raw_w{w_ll,kk}   = raw_w_comb;


### PR DESCRIPTION
Updated twix-loader to support CMRR sequence with integrated water reference. Thanks to Jamie for doing most of the work in FID-A already.