### PR TITLE
[Bug fix] - dicom loading from file path

### DIFF
--- a/libraries/FID-A/inputOutput/io_loadspec_dicom.m
+++ b/libraries/FID-A/inputOutput/io_loadspec_dicom.m
@@ -16,6 +16,11 @@
 
 function out=io_loadspec_dicom(folder);
 
+% If path to a .dcm is provided, then extract the folder location:
+if ~isfolder(folder) && isfile(folder)
+    folder =fileparts(folder);
+end
+
 % Create list of complete filenames (incl. path) in the folder
 dirFolder = dir(folder);
 filesInFolder = dirFolder(~[dirFolder.isdir]);


### PR DESCRIPTION
Adds a check if the user-specified data location is a DICOM file, rather than a DICOM-containing directory, and updates accordingly.