### PR TITLE
[BUG FIX] - isMinn flag missing - io_loadsoec_tiwx

### DIFF
--- a/libraries/FID-A/inputOutput/io_loadspec_twix.m
+++ b/libraries/FID-A/inputOutput/io_loadspec_twix.m
@@ -657,7 +657,7 @@ end
 
 if isWIP529 || isWIP859
     leftshift = twix_obj.image.cutOff(1,1);
-elseif isSiemens && (~isMinn && ~isConnectom)
+elseif isSiemens && (~(isMinn_eja || isMinn_dkd) && ~isConnectom)
     if ~strcmp(version,'ve') && ~strcmp(version,'XA30')
         leftshift = twix_obj.image.freeParam(1);
     else


### PR DESCRIPTION
We have added isMinn_dkd and isMinn_eja to account for different water reference schemes and missed to update the obsolete isMinn flag. This has been fixed now.