### PR TITLE
Update io_loadspec_twix messages

### DIFF
--- a/libraries/FID-A/inputOutput/io_loadspec_twix.m
+++ b/libraries/FID-A/inputOutput/io_loadspec_twix.m
@@ -839,8 +839,8 @@ if wRefs
         out_w.flags.isHERCULES = 1;
     end
 else
-    %No water reference data found.  Returning empty struct for out_w:
-    disp('No water reference data found.  Returning empty field');
+    %No integrated water reference data found.  Returning empty struct for out_w:
+    disp('No integrated water reference data found.  Returning empty field');
     out_w=[];
 end
 


### PR DESCRIPTION
- The no water reference found message for the CMRR sequence is confusing. Updated the message slightly.