### PR TITLE
Cleanup osp_Toolbox_Check

### DIFF
--- a/GUI/osp_Toolbox_Check.m
+++ b/GUI/osp_Toolbox_Check.m
@@ -13,7 +13,7 @@ function [hasSPM,OspreyVersion] = osp_Toolbox_Check (Module,ToolChecked)
 %                              OspreyFit
 %                              OspreyCoreg
 %                              OspreySeg
-%      ToolChecked = Flag whether Toolboxes have been checked before. 
+%      ToolChecked = Flag whether Toolboxes have been checked before.
 %
 %   OUTPUTS:
 %       hasSPM     = SPM flag.
@@ -32,7 +32,7 @@ function [hasSPM,OspreyVersion] = osp_Toolbox_Check (Module,ToolChecked)
 %       2020-05-15: First version of the code.
 %% % 1. SAVE OSPREY VERSION%%%
 %%% 1. SAVE OSPREY VERSION%%%
-OspreyVersion = 'Osprey 2.5.0';
+OspreyVersion = 'Osprey 2.4.0';
 fprintf(['Timestamp %s ' OspreyVersion '  ' Module '\n'], datestr(now,'mmmm dd, yyyy HH:MM:SS'));
 hasSPM = 1; % For the compiled GUI
 %% % 2. GET SPMPATH AND TOOLBOXES%%%
@@ -40,43 +40,41 @@ if ~(ismcc || isdeployed)
     warning('off','MATLAB:javaclasspath:jarAlreadySpecified');
     addons = matlab.addons.installedAddons;
     available = cellstr(table2cell(addons(:,1)));
-    for tl = 1 : size(addons,1)
-        try
-            matlab.addons.enableAddon(addons.Name{tl});
-        catch
-        end
-    end
-    addons = matlab.addons.installedAddons;
     lic = strcmp({'Enabled'}, addons.Properties.VariableNames);
+
+    % older Matlab versions require identifier rather than name; create a map for this:
+    identifiers = containers.Map( addons.Name, addons.Identifier );
+
     if ~isempty(lic)
-        enabled = table2cell(addons(:,lic==1));
+        enabled=table2array(addons(:,lic));
     else
-        enabled = table2cell(addons(:,1));
+        % If for some reason we can't determine the "Enabled" state, assume NOT
+        % enabled and later try to enable on demand
+        enabled = zeros(length(available),1);
     end
-    
+
     [settingsFolder,~,~] = fileparts(which('OspreySettings.m'));
     allFolders      = strsplit(settingsFolder, filesep);
     ospFolder       = strjoin(allFolders(1:end-1), filesep); % parent folder (= Osprey folder)
-     
+
     % Get SPM folder and check if SPM12 is installed
     spmversion = fileparts(which(fullfile('spm.m')));
     if isempty(spmversion)
         hasSPM = 0;
     elseif strcmpi(spmversion(end-3:end),'spm8')
         available{end+1} = 'SPM8';
-        enabled{end+1} = false;
+        enabled(end+1) = false;
         hasSPM = 0;
     else
         available{end+1} = 'SPM12';
-        enabled{end+1} = true;
+        enabled(end+1) = true;
         hasSPM = 1;
-    end 
-    
+    end
+
+    opts.Interpreter = 'tex';
+    opts.WindowStyle = 'modal';
+
     try
-        if ~isempty(lic)
-            available(find(cellfun(@(a)~isempty(a)&&a<1,enabled)), :) = [];
-        end    
-    
         %%% 3. CHECK AVAILABILTY %%%
         switch Module
             case 'OspreyGUI'
@@ -86,7 +84,7 @@ if ~(ismcc || isdeployed)
             case 'OspreyProcess'
                 ModuleString = 'run \bfOspreyProcess';
                 neededGlobal = {'Optimization Toolbox', 'Statistics and Machine Learning Toolbox','SPM12'};
-                neededSpecific = {'Optimization Toolbox', 'Statistics and Machine Learning Toolbox'}; 
+                neededSpecific = {'Optimization Toolbox', 'Statistics and Machine Learning Toolbox'};
             case 'OspreyFit'
                 ModuleString = 'run \bfOspreyFit';
                 neededGlobal = {'Optimization Toolbox', 'Statistics and Machine Learning Toolbox','SPM12'};
@@ -98,32 +96,52 @@ if ~(ismcc || isdeployed)
             case 'OspreySeg'
                 ModuleString = 'run \bfOspreySeg';
                 neededGlobal = {'Optimization Toolbox', 'Statistics and Machine Learning Toolbox','SPM12'};
-                neededSpecific = {'SPM12'};        
+                neededSpecific = {'SPM12'};
             otherwise
                 ModuleString = ['run \bf' Module];
                 neededGlobal = {'Optimization Toolbox', 'Statistics and Machine Learning Toolbox','SPM12'};
                 neededSpecific = cellstr({});
         end
-        
+
+        neededAll=union(neededGlobal,neededSpecific);
+
         %To account for the re-naming of new downloads of the Widget Toolbox
         %for Matlab versions earlier than 2020b, while maintaining
         %functionality for older downloads, we need to check for all naming
         %conventions of the Widgets Toolbox HZ
-        for tb = 1 : length(available)
-            if contains(available{tb},'Widgets Toolbox')
-                available{tb} = 'Widgets Toolbox';
+        wtNeededIndex = find(strcmp(neededAll,'Widgets Toolbox'),1,'first');
+        if ~isempty(wtNeededIndex)
+            wtAvailableIndex = find(contains(available,'Widgets Toolbox'),1,'first');
+            if ~isempty(wtAvailableIndex)
+                widgetsName=available{wtAvailableIndex};
+                neededAll{wtNeededIndex} = widgetsName; % adopt name of the available variant
+                neededGlobal(strcmp(neededGlobal,'Widgets Toolbox')) = {widgetsName};
+                neededSpecific(strcmp(neededSpecific,'Widgets Toolbox')) = {widgetsName};
             end
         end
-        missingSpecific = setdiff(neededSpecific,available);
-        missing = setdiff(neededGlobal,available); 
-    
+
+        % First, check dependencies which may be available but not enabled:
+        tryEnable=intersect(available, setdiff(neededAll, available(enabled)));
+
+        for tl = 1: size(tryEnable,1)
+            try
+                name=tryEnable{tl};
+                identifier = identifiers(tryEnable{tl});
+                matlab.addons.enableAddon(identifier);
+                enabled(find(strcmp(available,name),1,'first')) = matlab.addons.isAddonEnabled(identifier);
+            catch
+            end
+        end
+
+        missingSpecific = setdiff(neededSpecific,available(enabled));
+        missing = setdiff(neededGlobal,available(enabled));
+
+
         %%% 4. CREATE WARNING MESSAGES %%%
         if ~ToolChecked
             warningMsg = cellstr({});
             warning_count = 1;
             if ~isempty(missing) || ~isempty(missingSpecific)
-                opts.Interpreter = 'tex';
-                opts.WindowStyle = 'modal';
                 warningMsg{1} = ['The following toolboxes are missing to ' ModuleString '\rm:'];
                 for i = 1 : length(missing)
                     warningMsg{i+1} = ['\bf' missing{i} '\rm'];
@@ -132,7 +150,7 @@ if ~(ismcc || isdeployed)
                 warningMsg{warning_count} = ['Please install them to ' ModuleString '\rm'];
                 warning_count = warning_count + 1;
                 if ~isempty(missingSpecific)
-                    warningMsg{warning_count} = ['The following toolboxes are missing to run ' Module ':']; 
+                    warningMsg{warning_count} = ['The following toolboxes are missing to run ' Module ':'];
                     warningc = ['Please install and include the following toolboxes to use ' Module ':'];
                     for i = 1 : length(missingSpecific)
                         warningMsg{warning_count + i} = ['\bf' missingSpecific{i} '\rm'];
@@ -141,16 +159,16 @@ if ~(ismcc || isdeployed)
                     warningMsg{warning_count + length(missingSpecific) + 1} = ['Please install them to use \bf' Module '\rm'];
                     warndlg(warningMsg,'Missing Toolboxes',opts);
                     error(warningc);
-                end    
+                end
                 warndlg(warningMsg,'Missing Toolboxes',opts);
             end
         end
-    
+
     catch %If the MATLAB version pre-dates the inmplementation of matlab.addons.installedAddons
         warningMsg = cellstr({});
         warningMsg{1} = 'Your current MATLAB version does not allow the automated toolbox check. We assume that all required toolboxes are available.';
         warndlg(warningMsg,'Automated toolbox check not working.',opts);
-    end   
+    end
     warning('on','MATLAB:javaclasspath:jarAlreadySpecified');
 end
 end


### PR DESCRIPTION
osp_Toolbox_Check would indiscriminately attempt to enable every addon available on the system, incurring substantial delay in certain cases. This patch selectively enables only the necessary ones.

On a test system (Linux, Matlab 2023b, >100 addons available) the osp_Toolbox_Check added about 10 seconds of startup time to every module which called it. This was mostly due to the loop at the top which blindly calls matlab.addons.enableAddon for every available addon (including un-needed addons, already enabled addons, and perhaps addons which have been deliberately disabled for a reason), every time the toolbox check is initiated.

Even so, it was unlikely to actually succeed in enabling the required addons on older releases, since enableAddon operates on the addon identifier rather than name (newer releases can accept either, perhaps unless there are multiple versions)

This patch:
- Selectively enables only those addons which are indicated as "needed" by the modle and which are not already enabled, and
- Maps the module name to the unique identifier to do so, thereby successfully enabling the addons even on older matlab releases

Tested R2023b and R2019a.
