### PR TITLE
[BUG FIX] - 180 flip not corrected before alignment - OspreyProcess -…

### DIFF
--- a/GUI/osp_Toolbox_Check.m
+++ b/GUI/osp_Toolbox_Check.m
@@ -32,7 +32,7 @@ function [hasSPM,OspreyVersion] = osp_Toolbox_Check (Module,ToolChecked)
 %       2020-05-15: First version of the code.
 %% % 1. SAVE OSPREY VERSION%%%
 %%% 1. SAVE OSPREY VERSION%%%
-OspreyVersion = 'Osprey 2.4.0';
+OspreyVersion = 'Osprey 2.5.0';
 fprintf(['Timestamp %s ' OspreyVersion '  ' Module '\n'], datestr(now,'mmmm dd, yyyy HH:MM:SS'));
 hasSPM = 1; % For the compiled GUI
 %% % 2. GET SPMPATH AND TOOLBOXES%%%

--- a/libraries/FID-A/inputOutput/io_loadspec_sdat.m
+++ b/libraries/FID-A/inputOutput/io_loadspec_sdat.m
@@ -26,11 +26,15 @@
 % OUTPUTS:
 % out        = Input dataset in FID-A structure format.
 
-function out = io_loadspec_sdat(filename,subspecs,series)
+function out = io_loadspec_sdat(filename,subspecs,series,undoPhaseCycle)
 
-if nargin<3
-    series = 0;
+if nargin<4
+    undoPhaseCycle = 1;
+    if nargin<3
+        series = 0;
+    end
 end
+
 % Read in the data and header information
 [data, header] = philipsLoad(filename);
 
@@ -80,8 +84,10 @@ dims.t = 1;
 % according to the 'subspecs' input.
 % Initialize fids array:
 fids = squeeze(zeros(header.samples, header.rows/subspecs, subspecs));
-% Remove phase cycle
-fids = fids .* repmat(conj(fids(1,:,:,:))./abs(fids(1,:,:,:)),[size(fids,1) 1]);
+if undoPhaseCycle
+    % Remove phase cycle
+    fids = fids .* repmat(conj(fids(1,:,:,:))./abs(fids(1,:,:,:)),[size(fids,1) 1]);
+end
 if subspecs == 2
     %Split the subspectra out of the "averages" dimension:
     fids(:,:,1) = data(:,[1:2:end]);

--- a/load/osp_LoadSDAT.m
+++ b/load/osp_LoadSDAT.m
@@ -71,16 +71,16 @@ for kk = 1:MRSCont.nDatasets(1)
             % type of sequence needs to be differentiated here already.
             metab_ll = MRSCont.opts.MultipleSpectra.metab(ll);
             if MRSCont.flags.isUnEdited
-                raw         = io_loadspec_sdat(MRSCont.files{metab_ll,kk},1,MRSCont.flags.isSERIES);
+                raw         = io_loadspec_sdat(MRSCont.files{metab_ll,kk},1,MRSCont.flags.isSERIES,MRSCont.opts.load.undoPhaseCycle);
                 raw.flags.isUnEdited = 1;
             elseif MRSCont.flags.isMEGA
-                raw         = io_loadspec_sdat(MRSCont.files{metab_ll,kk},2,MRSCont.flags.isSERIES);
+                raw         = io_loadspec_sdat(MRSCont.files{metab_ll,kk},2,MRSCont.flags.isSERIES,MRSCont.opts.load.undoPhaseCycle);
                 raw.flags.isMEGA = 1;
             elseif MRSCont.flags.isHERMES
-                raw         = io_loadspec_sdat(MRSCont.files{metab_ll,kk},4,MRSCont.flags.isSERIES);
+                raw         = io_loadspec_sdat(MRSCont.files{metab_ll,kk},4,MRSCont.flags.isSERIES,MRSCont.opts.load.undoPhaseCycle);
                 raw.flags.isHERMES = 1;
             elseif MRSCont.flags.isHERCULES
-                raw         = io_loadspec_sdat(MRSCont.files{metab_ll,kk},4,MRSCont.flags.isSERIES);
+                raw         = io_loadspec_sdat(MRSCont.files{metab_ll,kk},4,MRSCont.flags.isSERIES,MRSCont.opts.load.undoPhaseCycle);
                 raw.flags.isHERCULES = 1;
             end
             % Add NIfTI-MRS information
@@ -91,17 +91,17 @@ for kk = 1:MRSCont.nDatasets(1)
             if MRSCont.flags.hasMM %re_mm
                 temp_ll = MRSCont.opts.MultipleSpectra.mm(ll);
                 if MRSCont.flags.isUnEdited %re_mm                    
-                    raw_mm = io_loadspec_sdat(MRSCont.files_mm{temp_ll,kk},1,MRSCont.flags.isSERIES); %re_mm
+                    raw_mm = io_loadspec_sdat(MRSCont.files_mm{temp_ll,kk},1,MRSCont.flags.isSERIES,MRSCont.opts.load.undoPhaseCycle); %re_mm
                     [raw_mm] = op_rmempty(raw_mm); %re_mm
                     raw_mm.flags.isUnEdited = 1;
                 elseif MRSCont.flags.isMEGA %re_mm
-                    raw_mm = io_loadspec_sdat(MRSCont.files_mm{temp_ll,kk},2,MRSCont.flags.isSERIES); %re_mm
+                    raw_mm = io_loadspec_sdat(MRSCont.files_mm{temp_ll,kk},2,MRSCont.flags.isSERIES,MRSCont.opts.load.undoPhaseCycle); %re_mm
                     raw_mm.flags.isMEGA = 1;
                 elseif MRSCont.flags.isHERMES%re_mm
-                    raw_mm = io_loadspec_sdat(MRSCont.files_mm{temp_ll,kk},1,MRSCont.flags.isSERIES); %re_mm
+                    raw_mm = io_loadspec_sdat(MRSCont.files_mm{temp_ll,kk},1,MRSCont.flags.isSERIES,MRSCont.opts.load.undoPhaseCycle); %re_mm
                     raw_mm.flags.isHERMES = 1;
                 elseif MRSCont.flags.isHERCULES %re_mm
-                    raw_mm = io_loadspec_sdat(MRSCont.files_mm{temp_ll,kk},1,MRSCont.flags.isSERIES); %re_mm
+                    raw_mm = io_loadspec_sdat(MRSCont.files_mm{temp_ll,kk},1,MRSCont.flags.isSERIES,MRSCont.opts.load.undoPhaseCycle); %re_mm
                     raw_mm.flags.isHERCULES = 1;
                 end
                 % Add NIfTI-MRS information
@@ -113,23 +113,23 @@ for kk = 1:MRSCont.nDatasets(1)
             if MRSCont.flags.hasRef
                 ref_ll = MRSCont.opts.MultipleSpectra.ref(ll);
                 if MRSCont.flags.isUnEdited                    
-                    raw_ref = io_loadspec_sdat(MRSCont.files_ref{ref_ll,kk},1,MRSCont.flags.isSERIES);
+                    raw_ref = io_loadspec_sdat(MRSCont.files_ref{ref_ll,kk},1,MRSCont.flags.isSERIES,MRSCont.opts.load.undoPhaseCycle);
                     raw_ref = op_combine_water_subspecs(raw_ref,0);
                     raw_ref.flags.isUnEdited = 1;
                 elseif MRSCont.flags.isMEGA
                     try % GO 03042024: this works for the JHU patch only but throws an error for product MEGA
-                        raw_ref = io_loadspec_sdat(MRSCont.files_ref{ref_ll,kk},2,MRSCont.flags.isSERIES);
+                        raw_ref = io_loadspec_sdat(MRSCont.files_ref{ref_ll,kk},2,MRSCont.flags.isSERIES,MRSCont.opts.load.undoPhaseCycle);
                     catch % GO 03042024: this works for product MEGA
-                        raw_ref = io_loadspec_sdat(MRSCont.files_ref{ref_ll,kk},1,MRSCont.flags.isSERIES);
+                        raw_ref = io_loadspec_sdat(MRSCont.files_ref{ref_ll,kk},1,MRSCont.flags.isSERIES,MRSCont.opts.load.undoPhaseCycle);
                     end
                     raw_ref = op_combine_water_subspecs(raw_ref,0);
                     raw_ref.flags.isMEGA = 1;
                 elseif MRSCont.flags.isHERMES
-                    raw_ref = io_loadspec_sdat(MRSCont.files_ref{ref_ll,kk},1,MRSCont.flags.isSERIES);
+                    raw_ref = io_loadspec_sdat(MRSCont.files_ref{ref_ll,kk},1,MRSCont.flags.isSERIES,MRSCont.opts.load.undoPhaseCycle);
                     raw_ref = op_combine_water_subspecs(raw_ref,0);
                     raw_ref.flags.isHERMES = 1;
                  elseif MRSCont.flags.isHERCULES
-                    raw_ref = io_loadspec_sdat(MRSCont.files_ref{ref_ll,kk},1,MRSCont.flags.isSERIES);
+                    raw_ref = io_loadspec_sdat(MRSCont.files_ref{ref_ll,kk},1,MRSCont.flags.isSERIES,MRSCont.opts.load.undoPhaseCycle);
                     raw_ref = op_combine_water_subspecs(raw_ref,0);
                     raw_ref.flags.isHERCULES = 1;
                 end
@@ -139,7 +139,7 @@ for kk = 1:MRSCont.nDatasets(1)
             end
             if MRSCont.flags.hasWater
                 w_ll = MRSCont.opts.MultipleSpectra.w(ll);
-                raw_w   = io_loadspec_sdat(MRSCont.files_w{w_ll,kk},1,MRSCont.flags.isSERIES);
+                raw_w   = io_loadspec_sdat(MRSCont.files_w{w_ll,kk},1,MRSCont.flags.isSERIES,MRSCont.opts.load.undoPhaseCycle);
                 raw_w = op_combine_water_subspecs(raw_w,0);
                 raw_w.flags.isUnEdited = 1;
                 % Add NIfTI-MRS information
@@ -151,19 +151,19 @@ for kk = 1:MRSCont.nDatasets(1)
             if MRSCont.flags.hasMMRef
                 temp_ll = MRSCont.opts.MultipleSpectra.mm_ref(ll);
                 if MRSCont.flags.isUnEdited
-                    raw_mm_ref = io_loadspec_sdat(MRSCont.files_mm_ref{temp_ll,kk},1,MRSCont.flags.isSERIES);
+                    raw_mm_ref = io_loadspec_sdat(MRSCont.files_mm_ref{temp_ll,kk},1,MRSCont.flags.isSERIES,MRSCont.opts.load.undoPhaseCycle);
                     raw_mm_ref = op_combine_water_subspecs(raw_mm_ref,0);
                     raw_mm_ref.flags.isUnEdited = 1;
                 elseif MRSCont.flags.isMEGA
-                    raw_mm_ref = io_loadspec_sdat(MRSCont.files_mm_ref{temp_ll,kk},2,MRSCont.flags.isSERIES);
+                    raw_mm_ref = io_loadspec_sdat(MRSCont.files_mm_ref{temp_ll,kk},2,MRSCont.flags.isSERIES,MRSCont.opts.load.undoPhaseCycle);
                     raw_mm_ref = op_combine_water_subspecs(raw_mm_ref,0);
                     raw_mm_ref.flags.isMEGA = 1;
                 elseif MRSCont.flags.isHERMES
-                    raw_mm_ref = io_loadspec_sdat(MRSCont.files_mm_ref{temp_ll,kk},1,MRSCont.flags.isSERIES);
+                    raw_mm_ref = io_loadspec_sdat(MRSCont.files_mm_ref{temp_ll,kk},1,MRSCont.flags.isSERIES,MRSCont.opts.load.undoPhaseCycle);
                     raw_mm_ref = op_combine_water_subspecs(raw_mm_ref,0);
                     raw_mm_ref.flags.isHERMES = 1;
                  elseif MRSCont.flags.isHERCULES
-                    raw_mm_ref = io_loadspec_sdat(MRSCont.files_mm_ref{temp_ll,kk},1,MRSCont.flags.isSERIES);
+                    raw_mm_ref = io_loadspec_sdat(MRSCont.files_mm_ref{temp_ll,kk},1,MRSCont.flags.isSERIES,MRSCont.opts.load.undoPhaseCycle);
                     raw_mm_ref = op_combine_water_subspecs(raw_mm_ref,0);
                     raw_mm_ref.flags.isHERCULES = 1;
                 end

--- a/process/OspreyProcess.m
+++ b/process/OspreyProcess.m
@@ -391,7 +391,8 @@ for kk = 1:MRSCont.nDatasets(1) %Subject loop
             % actually have negative polarity, but end up positive in the data, so
             % that the spectrum needs to be flipped.
             if ~isfield(MRSCont.opts.SubSpecAlignment, 'polResidCr')
-                if isfield(MRSCont.opts.SubSpecAlignment, 'PreservePolarity') && ~MRSCont.opts.SubSpecAlignment.PreservePolarity
+                if ~isfield(MRSCont.opts.SubSpecAlignment, 'PreservePolarity') || ...
+                    (isfield(MRSCont.opts.SubSpecAlignment, 'PreservePolarity') && ~MRSCont.opts.SubSpecAlignment.PreservePolarity)
                     raw_Cr     = op_freqrange(raw,2.8,3.2);
                     % Determine the polarity of the respective peak: if the absolute of the
                     % maximum minus the absolute of the minimum is positive, the polarity


### PR DESCRIPTION
… Several reports

- New PreservePolarity flag was not implemented correctly. Therefore, not all datasets were polarity corrected before the spectral alignment.