### PR TITLE
Update for HBCD

### DIFF
--- a/job/OspreyJob.m
+++ b/job/OspreyJob.m
@@ -435,6 +435,11 @@ if strcmp(jobFileFormat,'json')
     else
         opts.load.undoPhaseCycle = 1;
     end
+    if isfield(jobStruct,'SubSpecOrder')
+        MRSCont.opts.Order = jobStruct.SubSpecOrder';
+    else
+        MRSCont.opts.Order = [];
+    end
     debug = '11';
     if isfield(jobStruct,'exportParams')
         MRSCont.opts.exportParams.flag = 1;

--- a/libraries/FID-A/inputOutput/io_loadspec_niimrs.m
+++ b/libraries/FID-A/inputOutput/io_loadspec_niimrs.m
@@ -294,7 +294,7 @@ if allDims(1)*allDims(2)*allDims(3) == 1 % x=y=z=1
                 sqzDims{end+1} = dimsFieldNames{rr};
             end
         end
-        subspecs    = 0;
+        subspecs    = 1;
     end
 
     if length(sqzDims)==5
@@ -348,11 +348,21 @@ if allDims(1)*allDims(2)*allDims(3) == 1 % x=y=z=1
         undoPhaseCycle = 1;
     end
     if isfield(hdr_ext, 'Manufacturer') && strcmp(hdr_ext.Manufacturer,'Philips')  && undoPhaseCycle
-        fids = fids .* repmat(conj(fids(1,:,:,:))./abs(fids(1,:,:,:)),[size(fids,1) 1]);
+        if hdr_ext.WaterSuppressed && hdr_ext.EchoTime == 0.080
+            fids(:,:,:,1:2:end) = -fids(:,:,:,1:2:end);
+        end
+        if hdr_ext.WaterSuppressed && hdr_ext.EchoTime == 0.035
+            fids(:,:,2:2:end,:) = -fids(:,:,2:2:end,:);
+        end
     end
-    if isfield(hdr_ext, 'Manufacturer') && strcmp(hdr_ext.Manufacturer,'GE') && undoPhaseCycle 
+    if isfield(hdr_ext, 'Manufacturer') && strcmp(hdr_ext.Manufacturer,'GE') && ~strcmp(hdr_ext.SequenceName,'hbcd2') && undoPhaseCycle 
         if hdr_ext.WaterSuppressed && hdr_ext.EchoTime == 0.080
             fids(:,:,2:2:end,:) = -fids(:,:,2:2:end,:);
+        end
+    else if isfield(hdr_ext, 'Manufacturer') && strcmp(hdr_ext.Manufacturer,'GE') && strcmp(hdr_ext.SequenceName,'hbcd2') && undoPhaseCycle
+            if ~hdr_ext.WaterSuppressed && hdr_ext.EchoTime == 0.080
+                fids = -fids;
+            end
         end
     end
 

--- a/process/osp_combineCoils.m
+++ b/process/osp_combineCoils.m
@@ -44,7 +44,7 @@ if nargin<5
             metab_ll = MRSCont.opts.MultipleSpectra.metab(ll);
             % For SPECIAL acquisitions, some of the sub-spectra need to be combined
             % prior to determining the CC coefficients. We'll set a flag here.
-            isSpecial = strcmpi(MRSCont.raw_uncomb{metab_ll,kk}.seq, 'special');
+            isSpecial = strcmpi(MRSCont.raw_uncomb{metab_ll,kk}.seq(1), 'special');
             MRSCont.flags.isSPECIAL = isSpecial;
             % Check if reference scans exist, if so, get CC coefficients from there
             if MRSCont.flags.hasRef

--- a/settings/version.json
+++ b/settings/version.json
@@ -1,3 +1,3 @@
-{"Version": "2.7.1",
- "Date": "August 20, 2024",
+{"Version": "2.7.2",
+ "Date": "September 10, 2024",
 "Description": "First digit for major releases, second digit for regular compiled releases, third digit for each commit to the develop branch. "}


### PR DESCRIPTION
- Added SubSpecOrder to json field for external ordering of subspectra
- Modified load nii for HBCD loading to apply 180 phase to FIDs if necessary instead of first-point phasing prior to coil-combination. Discussed with Richard
- Fixed a random bug in the combineCoils function