### PR TITLE
Fix mICheckBox, sICheckBox in osp_create_job_file

### DIFF
--- a/job/osp_create_job_file.m
+++ b/job/osp_create_job_file.m
@@ -82,14 +82,14 @@ switch app.IncludedMetabolitesDropDown.Value
         if app.GluCheckBox.Value, fprintf(fid,'%s',',"Glu"'); end
         if app.GlyCheckBox.Value, fprintf(fid,'%s',',"Gly"'); end
         if app.H2OCheckBox.Value, fprintf(fid,'%s',',"H2O"'); end
-        if app.InsCheckBox.Value, fprintf(fid,'%s',',"mI"'); end
+        if app.mICheckBox.Value, fprintf(fid,'%s',',"mI"'); end
         if app.LacCheckBox.Value, fprintf(fid,'%s',',"Lac"'); end
         if app.NAACheckBox.Value, fprintf(fid,'%s',',"NAA"'); end
         if app.NAAGCheckBox.Value, fprintf(fid,'%s',',"NAAG"'); end
         if app.PChCheckBox.Value, fprintf(fid,'%s',',"PCh"'); end
         if app.PCrCheckBox.Value, fprintf(fid,'%s',',"PCr"'); end
         if app.PECheckBox.Value, fprintf(fid,'%s',',"PE"'); end
-        if app.ScylloCheckBox.Value, fprintf(fid,'%s',',"sI"'); end
+        if app.sICheckBox.Value, fprintf(fid,'%s',',"sI"'); end
         if app.SerCheckBox.Value, fprintf(fid,'%s',',"Ser"'); end
         if app.TauCheckBox.Value, fprintf(fid,'%s',',"Tau"'); end
         if app.TyrosCheckBox.Value, fprintf(fid,'%s',',"Tyros",'); end


### PR DESCRIPTION
Commit 18a3692 updated the names of Ins and Scyllo, but the old checkbox names remained in the interactive job builder, causing it to fail when using a custom selection of metabolites.