### PR TITLE
[BUG FIX] - Multi-experiment + LCM export doesn't work - OspreyProces…

### DIFF
--- a/libraries/FID-A/inputOutput/io_writelcm.m
+++ b/libraries/FID-A/inputOutput/io_writelcm.m
@@ -80,7 +80,11 @@ fprintf(fid,' $SEQPAR');
 %fprintf(fid,'sig(real)\tsig(imag)\tfft(real)\tfft(imag)\n');
 %fprintf(fid,'Signal 1 out of %i in file\n',datsets);
 fprintf(fid,'\n ECHOT= %2.2f',te);
-fprintf(fid,'\n SEQ= ''%s''', in.seq);
+try
+    fprintf(fid,'\n SEQ= ''%s''', in.seq);
+catch
+    fprintf(fid,'\n SEQ= ''%s''', in.seq{1});
+end
 fprintf(fid,'\n HZPPPM= %5.6f',in.txfrq/1e6);
 fprintf(fid,'\n NUNFIL= %i',in.sz(1));
 fprintf(fid,'\n DELTAT= %5.6f' ,dwelltime);

--- a/process/OspreyProcess.m
+++ b/process/OspreyProcess.m
@@ -836,7 +836,7 @@ if MRSCont.opts.savePDF
 end
 
 % Optional: write edited files to LCModel .RAW files
-if MRSCont.opts.saveLCM && ~MRSCont.flags.isPRIAM && ~MRSCont.flags.isMRSI
+if MRSCont.opts.saveLCM && ~MRSCont.flags.isPRIAM && ~MRSCont.flags.isMRSI && MRSCont.nDatasets(2) == 1
     [MRSCont] = osp_saveLCM(MRSCont);
 end
 


### PR DESCRIPTION
…s and writelcm - JB #803

- Skip export of LCM for now if multi-experiment data is provided so that averaging can be performed first.

- Modify LCM write function to work with data that was averaged over two experiments in Osprey