### PR TITLE
Update osp_platform.m

### DIFF
--- a/utilities/osp_platform.m
+++ b/utilities/osp_platform.m
@@ -129,9 +129,11 @@ end
 
 function PLATFORM = init_platform           %-Initialise platform variables
 %==========================================================================
-if strcmpi(spm_check_version,'matlab')
+if ~exist('OCTAVE_VERSION','builtin')
+    % matlab
     comp = computer;
 else
+    % octave
     if ismac
         comp = uname.machine;
         switch comp


### PR DESCRIPTION
`getCurrentVersion` depended on an SPM function, `spm_check_version`; Osprey (GUI) calls this before `osp_Toolbox_Check`, causing an inelegant crash if SPM12 is not on the path. The fix is functionally equivalent, without the SPM dependency.