### PR TITLE
[BUG FIX] Crash due to unspecified output folder

### DIFF
--- a/job/osp_create_job_file.m
+++ b/job/osp_create_job_file.m
@@ -15,12 +15,10 @@ function jobm = osp_create_job_file(app)
 
 outputFolder = app.OutputFolderEditField.Value;
 
-if ~exist(outputFolder)
-    mkdir(outputFolder)
-end
-
 if isempty(outputFolder)
     outputFolder = cd;
+elseif ~exist(outputFolder, 'dir')
+    mkdir(outputFolder)
 end
 
 JobName = app.JobNameEditField.Value;
@@ -176,7 +174,7 @@ if ~isempty(app.T1DataText.Value{1})
 end
 
 fprintf(fid,'\n\t%s',['"file_stat": ["' app.StatcsvEditField.Value '"],']);
-fprintf(fid,'\n\t%s',['"outputFolder": ["' app.OutputFolderEditField.Value '"]']);
+fprintf(fid,'\n\t%s',['"outputFolder": ["' outputFolder '"]']);
 fprintf(fid,'\n%s','}');
 fclose(fid);
 


### PR DESCRIPTION
An empty (unspecified) output folder in the job builder caused crashes much later (eg, after processing), when assembling output filenames with the `[outputFolder filesep 'filename']` pattern. Typically this would first show up in the `osp_WriteBIDsTable` call, line 831, OspreyProcess. Previous `osp_create_job_file` partially addresses this, but did not save the adjusted value into the generated jobfile.

The present fix does this: the adjusted output folder (which defaults to the current working directory, if no alternative was supplied) is now saved in the job file as expected.

Note that a more complete solution could include validating this when loading the jobfile, and migrating from the `[outputFolder filesep 'filename']` pattern to `fullfile(outputFolder, 'filename')` which handles empty values more elegantly.