### PR TITLE
[BUG FIX] Unreasonably slow processing, due to large arbitrary scale on incoming data

### DIFF
--- a/libraries/FID-A/processingTools/op_creChoFit.m
+++ b/libraries/FID-A/processingTools/op_creChoFit.m
@@ -44,11 +44,15 @@ spec = in.specs;
 
 % Define the spectral range around the Cr-Cho peaks
 freqLim = ppm <= 3.02+0.15 & ppm >= 3.02-0.15;
-[~,i] = max(abs(spec(freqLim)));
+[scale,i] = max(abs(spec(freqLim)));
 freq2 = ppm(freqLim);
 maxFreq = freq2(i);
 freqLim = ppm <= maxFreq+0.58 & ppm >= maxFreq-0.42;
-specRange = real(spec(freqLim));
+
+scale = max(scale,1e-4); % ensure non-zero, non-negative scale for normalisation
+specRange = real(spec(freqLim)) / scale;
+% ARC 2025-10-29 : scale factor added to normalise arbitrarily-scaled input
+% data, which can lead to unpredictable (and unreasonably slow) performance
 
 % Create initial guesses for the fit parameters
 Baseline = (specRange(1) + specRange(end))/2;
@@ -68,11 +72,13 @@ nlinopts = statset(nlinopts,'MaxIter',400,'TolX',1e-6,'TolFun',1e-6);
 x0 = lsqcurvefit(@TwoLorentzModel, x0, ppm(freqLim)', real(specRange), lb, ub, lsqopts);
 [parsFit, residCr] = nlinfit(ppm(freqLim)', specRange, @TwoLorentzModel, x0, nlinopts);
 
+parsFit([1,5,6])=scale * parsFit([1,5,6]); % ARC 2025-10-29 : undo normalisation
+
 % Optional plotting of data and results
 if ~suppressPlot
     % Plot original data
     figure(101);
-    plot(ppm(freqLim),specRange);
+    plot(ppm(freqLim),scale * specRange);
     hold on
     % Plot the fit
     plot(ppm(freqLim),TwoLorentzModel(parsFit,ppm(freqLim)));


### PR DESCRIPTION
`op_creChoFit` when called by `OspreyProcess` : `op_robustSpecReg` : `op_measureDrift` was unreasonably slow on some datasets, adding some minutes to the `OspreyProcess` call.

This was due to the `lsqcurvefit` call running through to the iteration limit, rather than satisfying the convergence criteria (tolerance). This in turn was a result of the arbitrary scale of the inconing data, which can vary by many orders of magnitude between datasets. For datasets with large peak magnitude (eg, in the order of 10^7), tolerance criteria were almost never satisfied.

This also leads to very different performance (in terms of runtime, and perhaps modelling precision) depending on an arbitrary scaling factor -- ie, between sites, vendors, etc.

This fix applies a scaling factor to normalise the data before fitting, to ensure consistent performance regardless of scale. Naturally the final result is adjusted back to the original scale. For the tested GE datasets, this reduces processing time by almost two minutes; numeric outcomes indistinguishable.