### PR TITLE
Fix OspreyGUI crash

### DIFF
--- a/GUI/osp_iniOverviewWindow.m
+++ b/GUI/osp_iniOverviewWindow.m
@@ -520,7 +520,7 @@ end
         end
         
         %%%%%%%%%%%%% Run the MULTIVERSE tab if there are multi-model results %%%%%%%%%%%%
-        if size(MRSCont.quantify.CRLB,5)>1
+        if isfield(MRSCont.quantify,'CRLB') && size(MRSCont.quantify.CRLB,5)>1
             gui.layout.overviewTab.TabEnables{7} = 'on'; 
             gui.layout.overviewTab.Selection  = 7;
             


### PR DESCRIPTION
OspreyGUI was failing when loading an MRSCont containing already-quantified data without the CRLB field (eg, from a model other than Osprey-gLCM).