### PR TITLE
Add close all for correct plotly install

### DIFF
--- a/mrsi/OspreyMRSIHTMLReport.m
+++ b/mrsi/OspreyMRSIHTMLReport.m
@@ -60,6 +60,7 @@ catch
     fprintf('Failed to install plotly for offline HTML plotting. Consult getplotlyoffline.');
   end
 end
+close all;
 
 % Get colormaps and setup the inital path
 colormaps = MRSCont.colormap;


### PR DESCRIPTION
Close all figures when plotly was installed correclty